### PR TITLE
Use an internal flag instead of removing the action

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -50,6 +50,7 @@ class Restricted_Site_Access {
 			'field' 	=> 'settings_field_allowed',
 		),
 	);
+	private static $has_run = false;
 
 	/**
 	 * Handles initializing this class and returning the singleton instance after it's been cached.
@@ -118,9 +119,10 @@ class Restricted_Site_Access {
 	 * @param array $wp WordPress request
 	 */
 	public static function restrict_access( $wp ) {
-		if ( empty( $wp->query_vars['rest_route'] ) ) {
-			remove_action( 'parse_request', array( __CLASS__, 'restrict_access' ), 1 );	// only need it the first time
+		if ( self::$has_run ) {
+			return;
 		}
+		self::$has_run = true;
 		
 		$is_restricted = !( is_admin() || is_user_logged_in() || 2 != get_option( 'blog_public' ) || ( defined( 'WP_INSTALLING' ) && isset( $_GET['key'] ) ) );
 		if ( apply_filters( 'restricted_site_access_is_restricted', $is_restricted, $wp ) === false ) {


### PR DESCRIPTION
We were running into issues where using remove action inside a callback on the same action was removing the wrong callback. I have no idea why this was happening (perhaps because `parse_request` uses `do_action_ref_array()` instead of just `do_action()`?), but the functionality of only running the `restrict_access()` method once per request can be achieved more cleanly by using an internal property to track whether the method has been run already.
