### PR TITLE
I18n all the things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 Moving forward, this project will (more strictly) adhere to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+* Combed the plugin for untranslated strings (or those missing text-domains) and generate a .pot file for easier internationalization.
+
 ## [5.1] - 2014-11-29
 * Under the hood refactoring and clean up for performance and maintainability.
 * Small visual refinements to the settings panel.
@@ -73,6 +76,7 @@ Moving forward, this project will (more strictly) adhere to [Semantic Versioning
 * Initial public release
 
 
+[Unreleased]: https://github.com/10up/restricted-site-access/compare/master...develop
 [5.1]: https://github.com/10up/restricted-site-access/compare/5.0.1...5.1
 [5.0.1]: https://github.com/10up/restricted-site-access/compare/5.0...5.0.1
 [5.0]: https://github.com/10up/restricted-site-access/compare/4.0...5.0

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,21 @@
+module.exports = function(grunt) {
+
+	grunt.initConfig({
+
+		makepot: {
+			target: {
+				options: {
+					domainPath: 'localization/',
+					mainFile: 'restricted_site_access.php',
+					type: 'wp-plugin',
+					updateTimestamp: false,
+					updatePoFiles: true
+				}
+			}
+	}
+	});
+
+	grunt.loadNpmTasks('grunt-wp-i18n');
+
+	grunt.registerTask('i18n', ['makepot']);
+};

--- a/localization/restricted-site-access.pot
+++ b/localization/restricted-site-access.pot
@@ -1,0 +1,230 @@
+# Copyright (C) 2016 Jake Goldman, 10up, Oomph
+# This file is distributed under the GPLv2 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Restricted Site Access 5.1\n"
+"Report-Msgid-Bugs-To: "
+"https://wordpress.org/support/plugin/restricted_site_access\n"
+"POT-Creation-Date: 2016-03-29 01:22:24+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.4\n"
+
+#: restricted_site_access.php:70
+msgid "Handle restricted visitors"
+msgstr ""
+
+#: restricted_site_access.php:75
+msgid "Restriction message"
+msgstr ""
+
+#: restricted_site_access.php:80
+msgid "Redirect web address"
+msgstr ""
+
+#: restricted_site_access.php:90
+msgid "Redirection status code"
+msgstr ""
+
+#: restricted_site_access.php:95
+msgid "Restricted notice page"
+msgstr ""
+
+#: restricted_site_access.php:100
+msgid "Unrestricted IP addresses"
+msgstr ""
+
+#: restricted_site_access.php:245
+msgid "Public access to this site has been restricted."
+msgstr ""
+
+#: restricted_site_access.php:259
+msgid "Restricted Site Access plug-in is blocking public access to this site."
+msgstr ""
+
+#: restricted_site_access.php:286
+msgid ""
+"Please select the page you want to show restricted visitors. If no page is "
+"selected, WordPress will simply show a general restriction message."
+msgstr ""
+
+#: restricted_site_access.php:288
+msgid ""
+"Please enter the web address you would like to redirect restricted visitors "
+"to. If no address is entered, visitors will be redirected to the login "
+"screen."
+msgstr ""
+
+#: restricted_site_access.php:307
+msgid "Choose the method for handling visitors to your site that are restricted."
+msgstr ""
+
+#: restricted_site_access.php:313
+msgid ""
+"enter a single IP address (for example, 192.168.1.105) or an IP range using "
+"a network prefix (for example, 10.0.0.1/24). Enter your addresses carefully!"
+msgstr ""
+
+#: restricted_site_access.php:317
+msgid "Here is a handy calculator to check your prefix."
+msgstr ""
+
+#: restricted_site_access.php:319
+msgid ""
+"The redirection fields are only used when \"Handle restricted visitors\" is "
+"set to \"Redirect them to a specified web address\"."
+msgstr ""
+
+#: restricted_site_access.php:325
+msgid "The web address of the site you want the visitor redirected to."
+msgstr ""
+
+#: restricted_site_access.php:331
+msgid ""
+"redirect the visitor to the same path (URI) entered at this site. Typically "
+"used when there are two, very similar sites at different public web "
+"addresses; for instance, a parallel development server accessible on the "
+"Internet but not intended for the public."
+msgstr ""
+
+#: restricted_site_access.php:337
+msgid ""
+"Redirect status codes can provide certain visitors, particularly search "
+"engines, more information about the nature of the redirect. A 301 redirect "
+"tells search engines that a page has moved permanently to the new location. "
+"307 indicates a temporary redirect. 302 is an undefined redirect."
+msgstr ""
+
+#: restricted_site_access.php:356
+msgid "Restrict site access to visitors who are logged in or allowed by IP address"
+msgstr ""
+
+#: restricted_site_access.php:406
+msgid "Send them to the WordPress login screen"
+msgstr ""
+
+#: restricted_site_access.php:409
+msgid "Redirect them to a specified web address"
+msgstr ""
+
+#: restricted_site_access.php:412
+msgid "Show them a simple message"
+msgstr ""
+
+#: restricted_site_access.php:415
+msgid "Show them a specific WordPress page I've created"
+msgstr ""
+
+#: restricted_site_access.php:440
+msgid "Add"
+msgstr ""
+
+#: restricted_site_access.php:441
+msgid "Enter a single IP address or a range using a subnet prefix"
+msgstr ""
+
+#: restricted_site_access.php:443
+msgid "Add My Current IP Address"
+msgstr ""
+
+#: restricted_site_access.php:445
+msgid "To manage IP addresses, you must use a JavaScript enabled browser."
+msgstr ""
+
+#: restricted_site_access.php:456
+msgid "Access to this site is restricted."
+msgstr ""
+
+#: restricted_site_access.php:494
+msgid "Send restricted visitor to same path (relative URL) at the new web address"
+msgstr ""
+
+#: restricted_site_access.php:510
+msgid "301 Permanent"
+msgstr ""
+
+#: restricted_site_access.php:511
+msgid "302 Undefined"
+msgstr ""
+
+#: restricted_site_access.php:512
+msgid "307 Temporary"
+msgstr ""
+
+#: restricted_site_access.php:529
+msgid "Select a page"
+msgstr ""
+
+#: restricted_site_access.php:581
+msgid "Settings"
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Restricted Site Access"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "http://10up.com/plugins/restricted-site-access-wordpress/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"<strong>Limit access your site</strong> to visitors who are logged in or "
+"accessing the site from a set of specific IP addresses. Send restricted "
+"visitors to the log in page, redirect them, or display a message or page. "
+"<strong>Powerful control over redirection</strong>, including <strong>SEO "
+"friendly redirect headers</strong>. Great solution for Extranets, publicly "
+"hosted Intranets, or parallel development sites."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Jake Goldman, 10up, Oomph"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://10up.com"
+msgstr ""
+
+#: restricted_site_access.php:74
+msgctxt "default restriction message"
+msgid "Access to this site is restricted."
+msgstr ""
+
+#: restricted_site_access.php:306
+msgctxt "help topic"
+msgid "Handle restricted visitors"
+msgstr ""
+
+#: restricted_site_access.php:312
+msgctxt "help topic"
+msgid "Allowed IP addresses"
+msgstr ""
+
+#: restricted_site_access.php:324
+msgctxt "help topic"
+msgid "Redirect web address"
+msgstr ""
+
+#: restricted_site_access.php:330
+msgctxt "help topic"
+msgid "Redirect to the same path"
+msgstr ""
+
+#: restricted_site_access.php:336
+msgctxt "help topic"
+msgid "Redirection status code"
+msgstr ""
+
+#: restricted_site_access.php:342
+msgctxt "help screen title"
+msgid "Restricted Site Acccess"
+msgstr ""
+
+#: restricted_site_access.php:429 restricted_site_access.php:434
+msgctxt "remove IP address action"
+msgid "Remove"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+
+{
+  "name": "restricted-site-access",
+  "description": "Limit access to visitors who are logged in or allowed by IP addresses. Includes many options for handling blocked visitors.",
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-wp-i18n": "^0.5.4"
+  },
+  "author": "10up <sales@10up.com>",
+  "license": "GPLv2 (or later)"
+}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -524,9 +524,9 @@ class Restricted_Site_Access {
 			self::$rsa_options['page'] = 0;
 		}
 
-		wp_dropdown_pages(array( 
+		wp_dropdown_pages(array(
 			'selected'          => self::$rsa_options['page'],
-			'show_option_none'  => 'Select a page',
+			'show_option_none'  => __( 'Select a page', 'restricted-site-access' ),
 			'name'              => 'rsa_options[page]',
 			'id'                => 'rsa_page'
 		));

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -10,46 +10,10 @@
 */
 
 class Restricted_Site_Access {
-	
+
 	private static $rsa_options, $basename;
 	private static $settings_page = 'reading';
-	private static $fields = array(
-		'approach'		=> array(
-			'default' 	=> 1,
-			'label' 	=> 'Handle restricted visitors',
-			'field' 	=> 'settings_field_handling',
-		),
-		'message' 		=> array(
-			'default' 	=> 'Access to this site is restricted.',
-			'label' 	=> 'Restriction message',
-			'field' 	=> 'settings_field_message',
-		),
-		'redirect_url' 	=> array(
-			'default' 	=> '',
-			'label' 	=> 'Redirect web address',
-			'field' 	=> 'settings_field_redirect',
-		),
-		'redirect_path'	=> array(
-			'default' 	=> 0,
-			'label' 	=> 'Redirect to same path',
-			'field' 	=> 'settings_field_redirect_path',
-		),
-		'head_code'		=> array(
-			'default' 	=> 302,
-			'label' 	=> 'Redirection status code',
-			'field' 	=> 'settings_field_redirect_code',
-		),
-		'page' 			=> array(
-			'default' 	=> 0,
-			'label' 	=> 'Restricted notice page',
-			'field' 	=> 'settings_field_rsa_page',
-		),
-		'allowed' 		=> array(
-			'default' 	=> array(),
-			'label'		=> 'Unrestricted IP addresses',
-			'field' 	=> 'settings_field_allowed',
-		),
-	);
+	private static $fields;
 
 	/**
 	 * Handles initializing this class and returning the singleton instance after it's been cached.
@@ -63,6 +27,7 @@ class Restricted_Site_Access {
 		if ( null === $instance ) {
 			$instance = new self();
 			self::_add_actions();
+			self::populate_fields_array();
 		}
 
 		return $instance;
@@ -93,6 +58,49 @@ class Restricted_Site_Access {
 	 */
 	public static function load_textdomain() {
 		load_plugin_textdomain( 'restricted-site-access', false, dirname( self::$basename ) . '/localization/' );
+	}
+
+	/**
+	 * Populate Restricted_Site_Access::$fields with internationalization-ready field information.
+	 */
+	protected static function populate_fields_array() {
+		self::$fields = array(
+		'approach'      => array(
+			'default' => 1,
+			'label' 	=> __( 'Handle restricted visitors', 'restricted-site-access' ),
+			'field' 	=> 'settings_field_handling',
+		),
+		'message'       => array(
+			'default' => _x( 'Access to this site is restricted.', 'default restriction message', 'restricted-site-access' ),
+			'label' 	=> __( 'Restriction message', 'restricted-site-access' ),
+			'field' 	=> 'settings_field_message',
+		),
+		'redirect_url'  => array(
+			'default' => '',
+			'label'   => __( 'Redirect web address', 'restricted-site-access' ),
+			'field'   => 'settings_field_redirect',
+		),
+		'redirect_path'	=> array(
+			'default' => 0,
+			'label'   => 'Redirect to same path',
+			'field'   => 'settings_field_redirect_path',
+		),
+		'head_code'     => array(
+			'default' => 302,
+			'label'   => __( 'Redirection status code', 'restricted-site-access' ),
+			'field'   => 'settings_field_redirect_code',
+		),
+		'page'          => array(
+			'default' => 0,
+			'label' 	=> __( 'Restricted notice page', 'restricted-site-access' ),
+			'field'   => 'settings_field_rsa_page',
+		),
+		'allowed'       => array(
+			'default' => array(),
+			'label'   => __( 'Unrestricted IP addresses', 'restricted-site-access' ),
+			'field'   => 'settings_field_allowed',
+		),
+	);
 	}
 
 	/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -297,18 +297,50 @@ class Restricted_Site_Access {
 	 * Add restricted access help tab to screen
 	 */
 	public static function admin_head() {
-		$screen = get_current_screen();
+		$screen  = get_current_screen();
+		$content = array();
+
+		// Populate the tab contents.
+		$content[] = sprintf(
+			'<p><strong>%1$s</strong> - %2$s</p>',
+			_x( 'Handle restricted visitors', 'help topic', 'restricted-site-access' ),
+			__( 'Choose the method for handling visitors to your site that are restricted.', 'restricted-site-access' )
+		);
+
+		$content[] = sprintf(
+			'<p><strong>%1$s</strong> - %2$s %3$s</p><p>%4$s</p>',
+			_x( 'Allowed IP addresses', 'help topic', 'restricted-site-access' ),
+			__( 'enter a single IP address (for example, 192.168.1.105) or an IP range using a network prefix (for example, 10.0.0.1/24). Enter your addresses carefully!', 'restricted-site-access' ),
+			sprintf(
+				'<a href="http://www.csgnetwork.com/ipinfocalc.html">%s</a>',
+				/** translators: link to http://www.csgnetwork.com/ipinfocalc.html */
+				__( 'Here is a handy calculator to check your prefix.', 'restricted-site-access' )
+			),
+			__('The redirection fields are only used when "Handle restricted visitors" is set to "Redirect them to a specified web address".', 'restricted-site-access' )
+		);
+
+		$content[] = sprintf(
+			'<p><strong>%1$s</strong> - %2$s</p>',
+			_x( 'Redirect web address', 'help topic', 'restricted-site-access' ),
+			__( 'The web address of the site you want the visitor redirected to.', 'restricted-site-access' )
+		);
+
+		$content[] = sprintf(
+			'<p><strong>%1$s</strong> - %2$s</p>',
+			_x( 'Redirect to the same path', 'help topic', 'restricted-site-access' ),
+			__( 'redirect the visitor to the same path (URI) entered at this site. Typically used when there are two, very similar sites at different public web addresses; for instance, a parallel development server accessible on the Internet but not intended for the public.', 'restricted-site-access' )
+		);
+
+		$content[] = sprintf(
+			'<p><strong>%1$s</strong> - %2$s</p>',
+			_x( 'Redirection status code', 'help topic', 'restricted-site-access' ),
+			__( 'Redirect status codes can provide certain visitors, particularly search engines, more information about the nature of the redirect. A 301 redirect tells search engines that a page has moved permanently to the new location. 307 indicates a temporary redirect. 302 is an undefined redirect.', 'restricted-site-access' )
+		);
+
 		$screen->add_help_tab( array(
 			'id'      => 'restricted-site-access',
-			'title'   => __('Restricted Site Acccess'),
-			'content' => '
-				<p><strong>' . __('Handle restricted visitors','restricted-site-access') . '</strong> - ' . __('choose the method for handling visitors to your site that are restricted.','restricted-site-access') . '</p>
-				<p><strong>' . __('Allowed IP addresses','restricted-site-access') . '</strong> - ' . __('enter a single IP address (for example, 192.168.1.105) or an IP range using a network prefix (for example, 10.0.0.1/24). Enter your addresses carefully! Here\'s a','restricted-site-access') . ' <a href="http://www.csgnetwork.com/ipinfocalc.html" target="_blank">' . __('handy calculator','restricted-site-access') . '</a> ' . __('to check your prefix.','restricted-site-access') . '</p>
-				<p>' . __('The redirection fields are only used when "Handle restricted visitors" is set to "Redirect them to a specified web address".','restricted-site-access') . '</p>
-				<p><strong>' . __('Redirect web address','restricted-site-access') . '</strong> - ' . __('the web address of the site you want the visitor redirected to.','restricted-site-access') . '</p>
-				<p><strong>' . __('Redirect to same path','restricted-site-access') . '</strong> - ' . __('redirect the visitor to the same path (URI) entered at this site. Typically used when there are two, very similar sites at different public web addresses; for instance, a parallel development server accessible on the Internet but not intended for the public.','restricted-site-access') . '</p>
-				<p><strong>' . __('Redirection status code','restricted-site-access') . '</strong> - ' . __('redirect status codes can provide certain visitors, particularly search engines, more information about the nature of the redirect. A 301 redirect tells search engines that a page has moved permanently to the new location. 307 indicates a temporary redirect. 302 is an undefined redirect.','restricted-site-access') . '</p>
-			',
+			'title'   => _x( 'Restricted Site Acccess', 'help screen title', 'restricted-site-access' ),
+			'content' => implode( PHP_EOL, $content ),
 		) );
 	}
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -353,7 +353,7 @@ class Restricted_Site_Access {
 	?>
 		<p>
 			<input id="blog-restricted" type="radio" name="blog_public" value="2" <?php checked( $is_restricted ); ?> />
-			<label for="blog-restricted"><?php _e( 'Restrict site access to visitors who are logged in or allowed by IP address', 'restricted-site-access' ); ?></label>
+			<label for="blog-restricted"><?php esc_html_e( 'Restrict site access to visitors who are logged in or allowed by IP address', 'restricted-site-access' ); ?></label>
 		</p>
 	<?php
 	}
@@ -403,16 +403,16 @@ class Restricted_Site_Access {
 	?>
 		<fieldset id="rsa_handle_fields">
 			<input id="rsa-send-to-login" name="rsa_options[approach]" type="radio" value="1" <?php checked( self::$rsa_options['approach'], 1 ); ?> />
-			<label for="rsa-send-to-login"><?php _e('Send them to the WordPress login screen','restricted-site-access'); ?></label>
+			<label for="rsa-send-to-login"><?php esc_html_e( 'Send them to the WordPress login screen','restricted-site-access' ); ?></label>
 			<br />
 			<input id="rsa-redirect-visitor" name="rsa_options[approach]" type="radio" value="2" <?php checked( self::$rsa_options['approach'], 2 ); ?> />
-			<label for="rsa-redirect-visitor"><?php _e('Redirect them to a specified web address','restricted-site-access'); ?></label>
+			<label for="rsa-redirect-visitor"><?php esc_html_e('Redirect them to a specified web address', 'restricted-site-access' ); ?></label>
 			<br />
 			<input id="rsa-display-message" name="rsa_options[approach]" type="radio" value="3" <?php checked( self::$rsa_options['approach'], 3 ); ?> />
-			<label for="rsa-display-message"><?php _e('Show them a simple message','restricted-site-access'); ?></label>
+			<label for="rsa-display-message"><?php esc_html_e( 'Show them a simple message', 'restricted-site-access' ); ?></label>
 			<br />
 			<input id="rsa-unblocked-page" name="rsa_options[approach]" type="radio" value="4" <?php checked( self::$rsa_options['approach'], 4 ); ?> />
-			<label for="rsa-unblocked-page"><?php _e('Show them a specific WordPress page I\'ve created','restricted-site-access'); ?></label>
+			<label for="rsa-unblocked-page"><?php esc_html_e( 'Show them a specific WordPress page I\'ve created', 'restricted-site-access' ); ?></label>
 		</fieldset>
 	<?php
 	}
@@ -426,23 +426,23 @@ class Restricted_Site_Access {
 	?>
 		<div class="hide-if-no-js">
 			<div id="ip_list">
-				<div id="ip_list_empty" style="display: none;"><input type="text" name="rsa_options[allowed][]" value="" readonly="true" /> <a href="#remove" class="remove_btn"><?php _e( 'Remove' ); ?></a></div>
+				<div id="ip_list_empty" style="display: none;"><input type="text" name="rsa_options[allowed][]" value="" readonly="true" /> <a href="#remove" class="remove_btn"><?php echo esc_html( _x( 'Remove', 'remove IP address action', 'restricted-site-access' ) ); ?></a></div>
 			<?php
 				$ips = (array) self::$rsa_options['allowed'];
 				foreach ( $ips as $ip) {
 					if ( ! empty( $ip ) ) {
-						echo '<div><input type="text" name="rsa_options[allowed][]" value="' . esc_attr( $ip ) . '" readonly="true" /> <a href="#remove" class="remove_btn">' . __( 'Remove' ) . '</a></div>';
+						echo '<div><input type="text" name="rsa_options[allowed][]" value="' . esc_attr( $ip ) . '" readonly="true" /> <a href="#remove" class="remove_btn">' . _x( 'Remove', 'remove IP address action', 'restricted-site-access' ) . '</a></div>';
 					}
 				}
 			?>
 			</div>
 			<div>
 				<input type="text" name="newip" id="newip" /> <input class="button" type="button" id="addip" value="<?php _e( 'Add' ); ?>" />
-				<p class="description" style="display: inline;"><label for="newip"><?php _e('Enter a single IP address or a range using a subnet prefix','restricted-site-access'); ?></label></p>
+				<p class="description" style="display: inline;"><label for="newip"><?php esc_html_e( 'Enter a single IP address or a range using a subnet prefix', 'restricted-site-access' ); ?></label></p>
             </div>
-			<?php if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) { ?><input class="button" type="button" id="rsa_myip" value="<?php _e( 'Add My Current IP Address', 'restricted-site-access' ); ?>" style="margin-top: 5px;" data-myip="<?php echo esc_attr( $_SERVER['REMOTE_ADDR'] ); ?>" /><br /><?php } ?>
+			<?php if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) { ?><input class="button" type="button" id="rsa_myip" value="<?php esc_attr_e( 'Add My Current IP Address', 'restricted-site-access' ); ?>" style="margin-top: 5px;" data-myip="<?php echo esc_attr( $_SERVER['REMOTE_ADDR'] ); ?>" /><br /><?php } ?>
 		</div>
-		<p class="hide-if-js"><strong><?php _e('To manage IP addresses, you must use a JavaScript enabled browser.','restricted-site-access'); ?></strong></p>
+		<p class="hide-if-js"><strong><?php esc_html_e( 'To manage IP addresses, you must use a JavaScript enabled browser.', 'restricted-site-access' ); ?></strong></p>
 	<?php
 	}
 
@@ -491,7 +491,7 @@ class Restricted_Site_Access {
 		<fieldset><legend class="screen-reader-text"><span><?php _e( self::$rsa_options['redirect_path']['label'], 'restricted-site-access' ); ?></span></legend>
 			<label for="redirect_path">
 				<input type="checkbox" name="rsa_options[redirect_path]" value="1" id="redirect_path" class="rsa_redirect_field" <?php checked( self::$rsa_options['redirect_path'] ); ?> />
-				<?php _e( 'Send restricted visitor to same path (relative URL) at the new web address', 'restricted-site-access' ); ?></label>
+				<?php esc_html_e( 'Send restricted visitor to same path (relative URL) at the new web address', 'restricted-site-access' ); ?></label>
 		</fieldset>
 	<?php
 	}
@@ -507,9 +507,9 @@ class Restricted_Site_Access {
 		}
 	?>
 		<select name="rsa_options[head_code]" id="redirect_code" class="rsa_redirect_field">
-			<option value="301" <?php selected( self::$rsa_options['head_code'], 301 ); ?>><?php _e( '301 Permanent', 'restricted-site-access' ); ?></option>
-			<option value="302" <?php selected( self::$rsa_options['head_code'], 302 ); ?>><?php _e( '302 Undefined', 'restricted-site-access' ); ?></option>
-			<option value="307" <?php selected( self::$rsa_options['head_code'], 307 ); ?>><?php _e( '307 Temporary', 'restricted-site-access' ); ?></option>
+			<option value="301" <?php selected( self::$rsa_options['head_code'], 301 ); ?>><?php esc_html_e( '301 Permanent', 'restricted-site-access' ); ?></option>
+			<option value="302" <?php selected( self::$rsa_options['head_code'], 302 ); ?>><?php esc_html_e( '302 Undefined', 'restricted-site-access' ); ?></option>
+			<option value="307" <?php selected( self::$rsa_options['head_code'], 307 ); ?>><?php esc_html_e( '307 Temporary', 'restricted-site-access' ); ?></option>
 		</select>
 	<?php
 	}
@@ -575,17 +575,22 @@ class Restricted_Site_Access {
 	 * @return array
 	 */
 	public static function plugin_action_links( $links ) {
-		$links[] = '<a href="options-' . self::$settings_page . '.php">' . __('Settings') . '</a>';
-		return $links; 
+		$links[] = sprintf(
+			'<a href="options-%s.php">%s</a>',
+			esc_attr( self::$settings_page ),
+			__( 'Settings', 'settings page link', 'restricted-site-access' )
+		);
+
+		return $links;
 	}
-	
+
 	/**
 	 * activation of plugin: upgrades old versions, immediately sets privacy
 	 */
 	public static function activation() {
 		update_option( 'blog_public', 2 );
 	}
-	
+
 	/**
 	 * restore privacy option to default value upon deactivating
 	 */


### PR DESCRIPTION
I've combed the existing codebase to find hard-coded strings not ready for internationalization and fixed strings that were either missing a text-domain or needed context (via `_x()`). Furthermore, I've improved late-escaping of translated strings as they're used throughout the plugin.

Finally, the [`grunt-wp-i18n`](https://github.com/cedaro/grunt-wp-i18n) package has been installed so we can easily rebuild the .pot file with each new release by running `grunt i18n` (the latest file is included in this PR).
