### PR TITLE
Delete the `remove_action( 'parse_request'` call.

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -118,10 +118,6 @@ class Restricted_Site_Access {
 	 * @param array $wp WordPress request
 	 */
 	public static function restrict_access( $wp ) {
-		if ( empty( $wp->query_vars['rest_route'] ) ) {
-			remove_action( 'parse_request', array( __CLASS__, 'restrict_access' ), 1 );	// only need it the first time
-		}
-
 		$is_restricted = !( is_admin() || is_user_logged_in() || 2 != get_option( 'blog_public' ) || ( defined( 'WP_INSTALLING' ) && isset( $_GET['key'] ) ) );
 		if ( apply_filters( 'restricted_site_access_is_restricted', $is_restricted, $wp ) === false ) {
 			return;


### PR DESCRIPTION
parse_request is only called for the main query, and not for queries
made with WP_Query, and removing it in the middle of the foreach for
processing actions causes really strange bugs (like completely bypassing
WP API routes, among other issues)
