### PR TITLE
Use sessions if IP validated

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -248,6 +248,7 @@ class Restricted_Site_Access {
 
 				// check if the masked versions match
 				if ( ( inet_pton( $ip ) & $mask ) == ( $remote_ip & $mask ) ) {
+					session_start();
 					return;
 				}
 			}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -248,7 +248,7 @@ class Restricted_Site_Access {
 
 				// check if the masked versions match
 				if ( ( inet_pton( $ip ) & $mask ) == ( $remote_ip & $mask ) ) {
-					session_start();
+					do_action( 'restrict_site_access_ip_match', $remote_ip, $ip, $mask ); // allow users to hook ip match
 					return;
 				}
 			}


### PR DESCRIPTION
If you use this plugin behind a Varnish cache (or other proxy based caches), you run into a weird problem.

Assume: 

1) A shared IP is granted permissions to view
2) Caching for non-logged in users is allowed (this is a common Varnish setup on DreamHost, WPEngine, etc)

Test:

As a person from the permitted IP range, visit the site.

Next, as a person NOT on the IP range, visit the site.

The second person will see the cached page.

Fix: 

By adding in session_start() to the IP check, it ensures Varnish type cache will not cache the page. The drop on speed/performance due to lack of cache should be acceptable if the goal here is privacy.

Alternative, maybe make that bit hookable so we can add in extra doohikies as needed?

(NB: I know you strongly recommend disabling caching while restricting access - me too! Sadly, this is not always possible for users on managed hosts)