### PR TITLE
Redirect to the "rsa-unblocked-page" instead of overridding query vars

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -258,10 +258,16 @@ class Restricted_Site_Access {
 
 		switch ( $rsa_restrict_approach ) {
 			case 4:
-				if ( ! empty( self::$rsa_options['page'] ) && ( $page_id = get_post_field( 'ID', self::$rsa_options['page'] ) ) ) {
-					unset( $wp->query_vars );
-					$wp->query_vars['page_id'] = $page_id;
-					return;
+				if ( ! empty( self::$rsa_options['page'] ) ) {
+					$page = get_post( self::$rsa_options['page'] );
+
+					// Prevents infinite loops.
+					if ( $wp->query_vars['pagename'] !== $page->post_name ) {
+						self::$rsa_options['redirect_url'] = get_permalink( $page->ID );
+						break;
+					} else {
+						return;
+					}
 				}
 
 			case 3:


### PR DESCRIPTION
Hi @adamsilverstein here's the PR 😉 

When BuddyPress is activated, every BP Pages (eg: site.url/members) are reachable when the approach si to show the user a specific page.
Using a redirect to the rsa-unblocked-page fixes the issue.

See #16