### PR TITLE
Remove remove_action that cause an error in hooked functions

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -193,10 +193,6 @@ class Restricted_Site_Access {
 	 * @param array $wp WordPress request
 	 */
 	public static function restrict_access( $wp ) {
-		if ( empty( $wp->query_vars['rest_route'] ) ) {
-			remove_action( 'parse_request', array( __CLASS__, 'restrict_access' ), 1 );	// only need it the first time
-		}
-
 		self::$rsa_options = self::get_options();
 		$mode = self::get_network_mode();
 


### PR DESCRIPTION
Removing the hooked action inside the function itself will skip an iteration in priority that will result in hooked functions not executed.

This is core bug
https://core.trac.wordpress.org/ticket/9968

You can reproduce this by the following code
```
add_action( 'init', 'first_callback', 777 );
add_action( 'init', 'second_callback', 778 );
add_action( 'init', 'third_callback', 779 );

function first_callback() {
	remove_action( 'init', 'first_callback', 777 );
}

function second_callback() {
	die( 'This want get executed' );
}

function third_callback() {
	// This will get executed
}
```

I am not sure why we want to remove the action just to make sure it only executed once?
What are the usecase that this function is executed twice in a request?