### PR TITLE
Handle "no role for site" users in multisite

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -223,9 +223,12 @@ class Restricted_Site_Access {
 	 */
 	protected static function user_can_access() {
 		/**
-		 * Filters whether the user can access before any other checks as a short-circuit.
+		 * Filters whether the user can access the site before any other checks.
 		 *
-		 * @param bool $access Whether the user can access
+		 * Returning a non-null value will short-circuit the function
+		 * and return that value instead.
+		 *
+		 * @param null|bool $access Whether the user can access the site.
 		 */
 		$access = apply_filters( 'restricted_site_access_user_can_access', null );
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -206,16 +206,50 @@ class Restricted_Site_Access {
 			$blog_public = get_site_option( 'blog_public', 2 );
 		}
 
-		$user_check = is_user_logged_in();
-
-		if ( is_multisite() ) {
-			$user_id    = get_current_user_id();
-			$user_check = is_user_logged_in() && ( is_super_admin( $user_id ) || is_user_member_of_blog( $user_id ) );
-		}
+		$user_check = self::user_can_access();
 
 		$checks = is_admin() || $user_check || 2 !== (int) $blog_public || ( defined( 'WP_INSTALLING' ) && isset( $_GET['key'] ) );
 
 		return ! $checks;
+	}
+
+	/**
+	 * Check if current user has access.
+	 *
+	 * Can be short-circuited using the `restricted_site_access_user_can_access` filter
+	 * to return a value other than null (boolean recommended).
+	 *
+	 * @return bool Whether the user has access
+	 */
+	protected static function user_can_access() {
+		/**
+		 * Filters whether the user can access before any other checks as a short-circuit.
+		 *
+		 * @param bool $access Whether the user can access
+		 */
+		$access = apply_filters( 'restricted_site_access_user_can_access', null );
+
+		if ( null !== $access ) {
+			return $access;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		if ( is_multisite() ) {
+			$user_id = get_current_user_id();
+
+			if ( is_super_admin( $user_id ) ) {
+				return true;
+			}
+
+			if ( is_user_member_of_blog( $user_id ) && current_user_can( 'read' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
For #33: Do an explicit check for `read` permissions instead of just logged in/member state.

This is an issue with multisite and `no role on site`, which does not remove the user from the site.

Also adds the `restricted_site_access_user_can_access` filter as a short-circuit for restoration of old behavior or further customization of user permission checking.