### PR TITLE
Avoid infinite redirect loop for a static page on front

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -301,6 +301,7 @@ class Restricted_Site_Access {
 			case 4:
 				if ( ! empty( self::$rsa_options['page'] ) ) {
 					$page = get_post( self::$rsa_options['page'] );
+
 					// If the selected page isn't found or isn't published, fall back to default values.
 					if ( ! $page || 'publish' !== $page->post_status ) {
 						self::$rsa_options['head_code'] = 302;
@@ -309,13 +310,15 @@ class Restricted_Site_Access {
 						break;
 					}
 
-					// Prevents infinite loops.
-					if ( ! isset( $wp->query_vars['pagename'] ) || $wp->query_vars['pagename'] !== $page->post_name ) {
-						self::$rsa_options['redirect_url'] = get_permalink( $page->ID );
-						break;
-					} else {
+					// Are we already on the selected page?
+					if (
+						( isset( $wp->query_vars['pagename'] ) && $wp->query_vars['pagename'] === $page->post_name )
+						) {
 						return;
 					}
+
+					self::$rsa_options['redirect_url'] = get_permalink( $page->ID );
+					break;
 				}
 
 			case 3:

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -311,8 +311,11 @@ class Restricted_Site_Access {
 					}
 
 					// Are we already on the selected page?
+					// There's a separate unpleasant conditional to match the page on front because of the way query vars are (not) filled at this point
 					if (
 						( isset( $wp->query_vars['pagename'] ) && $wp->query_vars['pagename'] === $page->post_name )
+						||
+						( empty ( $wp->query_vars ) && 'page' === get_option( 'show_on_front' ) && (int) self::$rsa_options['page'] === (int) get_option( 'page_on_front' ) )
 						) {
 						return;
 					}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -301,12 +301,12 @@ class Restricted_Site_Access {
 			case 4:
 				if ( ! empty( self::$rsa_options['page'] ) ) {
 					$page = get_post( self::$rsa_options['page'] );
-
-					// If the selected page isn't found, fall back to default values.
-					if ( ! $page ) {
+					// If the selected page isn't found or isn't published, fall back to default values.
+					if ( ! $page || 'publish' !== $page->post_status ) {
 						self::$rsa_options['head_code'] = 302;
 						$current_path = empty( $_SERVER['REQUEST_URI'] ) ? home_url() : $_SERVER['REQUEST_URI'];
 						self::$rsa_options['redirect_url'] = wp_login_url( $current_path );
+						break;
 					}
 
 					// Prevents infinite loops.

--- a/tests/php/restricted_site_access.php
+++ b/tests/php/restricted_site_access.php
@@ -67,7 +67,7 @@ class RestrictedSiteAccessTests extends \PHPUnit\Framework\TestCase {
 			'get_post',
 			array(
 				'times' => 1,
-				'return' => (object) array( 'ID' => 1 ),
+				'return' => (object) array( 'ID' => 1, 'post_status' => 'publish' ),
 			)
 		);
 		\WP_Mock::onFilter( 'restricted_site_access_approach' )


### PR DESCRIPTION
Fixes #53

In the situation there is a static page on front assigned for a site _and_ that page is selected as the page to be redirected to, you end up in an infinite loop. This is because at the point that this is happening (the `parse_request` hook), `$wp_query` has not been filled yet (making conditionals like `is_front_page()` useless) and the special case of a static page on front means that `$wp->query_vars` is empty. This flips some logic to make things more readable and adds a special check for this situation. I'm not sure if this is the absolute best conditional to use, very open to other suggestions.

This PR also avoids redirecting to a page that's been un-published since its assignment as the redirect page, which was not reported that I'm aware of but I noticed as I was testing the switch case.

And finally, we could really really use some tests here. I haven't managed to wrap my head around what exactly we'd need to test here since it's so specific to the way WP parses the request. Additionally, we would need to catch any changes in core, so the current set up using `WP_Mock` might not work for that.