### PR TITLE
Correct doc return documentation

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -22,7 +22,7 @@ class Restricted_Site_Access {
 	/**
 	 * Handles initializing this class and returning the singleton instance after it's been cached.
 	 *
-	 * @return null|Restricted Site Access
+	 * @return null|Restricted_Site_Access
 	 */
 	public static function get_instance() {
 		// Store the instance locally to avoid private static replication

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -22,7 +22,7 @@ class Restricted_Site_Access {
 	/**
 	 * Handles initializing this class and returning the singleton instance after it's been cached.
 	 *
-	 * @return null|Simple_page_Ordering
+	 * @return null|Restricted Site Access
 	 */
 	public static function get_instance() {
 		// Store the instance locally to avoid private static replication


### PR DESCRIPTION
Hello !

Could you please use this PR?

I just found this documentation error on the plugin while taking a look at the code:

` 	 * @return null|Simple_page_Ordering`

Got a bit confused because of it. It is now changed to `Restricted Site Access`

Thanks! :) 
