### PR TITLE
Feature/config constant to enforce restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ As of version 7.0.0, CLI integration has been added. To see the available comman
 $ wp rsa
 ```
 
-### How can I programatically define whitelisted IPs?
+### How can I programmatically define whitelisted IPs?
 
 In 7.0.0, the capacity to define a pipe delimited array of whitelisted IP addresses via constant was introduced.
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ In your `wp-config.php` file, you can define the following:
 define( 'RSA_IP_WHITELIST', '192.0.0.1|192.0.0.10' );
 ```
 
+### Is there a constant I can set to ensure my site is (or is not) restricted?
+
+As of version 7.1.0, two constants were introduced that give you the ability to specify if the site should be in restricted mode.
+
+You can force the plugin to be in restricted mode by adding the following to your `wp-config.php` file:
+
+```php
+define( 'RSA_FORCE_RESTRICTION', true );
+```
+Or to ensure your site won't be in restricted mode:
+
+```php
+define( 'RSA_FORBID_RESTRICTION', true );
+```
+
+Make sure you add it before the `/* That's all, stop editing! Happy blogging. */` line.
+
+Please note that setting `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTRICTION` if both are set.
+
 ## License
 
 Restricted Site Access is free software; you can redistribute it and/or modify it under the terms of the [GNU General Public License](http://www.gnu.org/licenses/gpl-2.0.html) as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -65,12 +65,12 @@ class Restricted_Site_Access {
 	public static function handle_constants( $is_restricted ) {
 		// Check if constant forcing restriction is defined
 		if ( defined( 'RSA_FORCE_RESTRICTION' ) && RSA_FORCE_RESTRICTION === true ) {
-			$is_restricted = true;
+			return true;
 		}
 
 		// Check if constant disallowing restriction is defined
 		if ( defined( 'RSA_FORBID_RESTRICTION' ) && RSA_FORBID_RESTRICTION === true ) {
-			$is_restricted = false;
+			return false;
 		}
 
 		return $is_restricted;

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -58,6 +58,22 @@ class Restricted_Site_Access {
 		add_action( 'wpmu_new_blog', array( __CLASS__, 'set_defaults' ), 10, 6 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_script' ) );
 		add_action( 'wp_ajax_rsa_notice_dismiss', array( __CLASS__, 'ajax_notice_dismiss' ) );
+
+		add_filter( 'restricted_site_access_is_restricted', array( __CLASS__, 'handle_constants' ) );
+	}
+
+	public static function handle_constants( $is_restricted ) {
+		// Check if constant forcing restriction is defined
+		if ( defined( 'RSA_FORCE_RESTRICTION' ) && RSA_FORCE_RESTRICTION === true ) {
+			$is_restricted = true;
+		}
+
+		// Check if constant disallowing restriction is defined
+		if ( defined( 'RSA_FORBID_RESTRICTION' ) && RSA_FORBID_RESTRICTION === true ) {
+			$is_restricted = false;
+		}
+
+		return $is_restricted;
 	}
 
 	public static function ajax_notice_dismiss() {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -59,7 +59,7 @@ class Restricted_Site_Access {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_script' ) );
 		add_action( 'wp_ajax_rsa_notice_dismiss', array( __CLASS__, 'ajax_notice_dismiss' ) );
 
-		add_filter( 'restricted_site_access_is_restricted', array( __CLASS__, 'handle_constants' ) );
+		add_filter( 'restricted_site_access_is_restricted', array( __CLASS__, 'handle_constants' ), 99 );
 	}
 
 	public static function handle_constants( $is_restricted ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -63,12 +63,12 @@ class Restricted_Site_Access {
 	}
 
 	public static function handle_constants( $is_restricted ) {
-		// Check if constant forcing restriction is defined
+		// Check if constant forcing restriction is defined.
 		if ( defined( 'RSA_FORCE_RESTRICTION' ) && RSA_FORCE_RESTRICTION === true ) {
 			return true;
 		}
 
-		// Check if constant disallowing restriction is defined
+		// Check if constant disallowing restriction is defined.
 		if ( defined( 'RSA_FORBID_RESTRICTION' ) && RSA_FORBID_RESTRICTION === true ) {
 			return false;
 		}


### PR DESCRIPTION
Resolves issue #63 

Adds the ability to use `define( 'RSA_FORCE_RESTRICTION', true );` in the `wp-config.php` file to ensure that the site is in restricted mode. You can also do `define( 'RSA_FORBID_RESTRICTION', true );` if you want to make sure a public site won't be restricted by accident.