### PR TITLE
Fix multisite redirect loop. Fixes #39

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -483,7 +483,7 @@ class Restricted_Site_Access {
 
 		foreach ( $blogs as $blog ) {
 			$output .= '<tr>';
-			$output .= '<td>' . esc_html( $blog_name ) . '</td>';
+			$output .= '<td>' . esc_html( $blog->blogname ) . '</td>';
 			$output .= '<td><a href="' . esc_url( get_admin_url( $blog->userblog_id ) ) . '">' . esc_html__( 'Visit Dashboard', 'restricted-site-access' ) . '</a> | ' .
 					'<a href="' . esc_url( get_home_url( $blog->userblog_id ) ) . '">' . esc_html__( 'View Site', 'restricted-site-access' ) . '</a></td>';
 			$output .= '</tr>';

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -471,11 +471,11 @@ class Restricted_Site_Access {
 
 		if ( empty( $blogs ) ) {
 			// Translators: %1$s: The site name.
-			wp_die( sprintf( esc_html__( 'You attempted to access the "%1$s" site, but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ), 403 );
+			wp_die( sprintf( esc_html__( 'You attempted to access the "%1$s" site, but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), esc_html( $blog_name ) ), 403 );
 		}
 
 		// Translators: %1$s: The site name.
-		$output  = '<p>' . sprintf( esc_html__( 'You attempted to access the "%1$s", but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ) . '</p>';
+		$output  = '<p>' . sprintf( esc_html__( 'You attempted to access the "%1$s", but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), esc_html( $blog_name ) ) . '</p>';
 		$output .= '<p>' . esc_html__( 'If you reached this screen by accident and meant to visit one of your own sites, here are some shortcuts to help you find your way.', 'restricted-site-access' ) . '</p>';
 
 		$output .= '<h3>' . esc_html__( 'Your Sites', 'restricted-site-access' ) . '</h3>';

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -491,7 +491,7 @@ class Restricted_Site_Access {
 
 		$output .= '</table>';
 
-		wp_die( $output, 403 ); // @codingStandardsIgnoreLine All content already escaped.
+		wp_die( wp_kses_post( $output ), 403 ); // @codingStandardsIgnoreLine All content already escaped.
 	}
 
 	/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -431,6 +431,7 @@ class Restricted_Site_Access {
 				}
 				// No break, fall thru to default.
 			default:
+				self::validate_blog_access();
 				self::$rsa_options['head_code']    = 302;
 				$current_path                      = empty( $_SERVER['REQUEST_URI'] ) ? home_url() : sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 				self::$rsa_options['redirect_url'] = wp_login_url( $current_path );
@@ -443,6 +444,54 @@ class Restricted_Site_Access {
 			'url'  => $redirect_url,
 			'code' => $redirect_code,
 		);
+	}
+
+	/**
+	 * Ensure the user has access to the blog attempting to be accessed.
+	 *
+	 * This method borrows from core's _access_denied_splash() for multi-site installs.
+	 */
+	public static function validate_blog_access() {
+	    if ( ! is_multisite() || ! is_user_logged_in() ) {
+	    	return;
+	    }
+
+	    if ( is_user_member_of_blog() || is_network_admin() ) {
+			return;
+		}
+
+		// We're logged in but not a member of this blog, let the user know.
+		$blogs = get_blogs_of_user( get_current_user_id() );
+
+		if ( wp_list_filter( $blogs, array( 'userblog_id' => get_current_blog_id() ) ) ) {
+			return;
+		}
+
+		$blog_name = get_bloginfo( 'name' );
+
+		if ( empty( $blogs ) ) {
+			// Translators: %1$s: The site name.
+			wp_die( sprintf( __( 'You attempted to access the "%1$s" site, but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ), 403 );
+		}
+
+		// Translators: %1$s: The site name.
+		$output  = '<p>' . sprintf( __( 'You attempted to access the "%1$s", but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ) . '</p>';
+		$output .= '<p>' . __( 'If you reached this screen by accident and meant to visit one of your own sites, here are some shortcuts to help you find your way.', 'restricted-site-access' ) . '</p>';
+
+		$output .= '<h3>' . __( 'Your Sites', 'restricted-site-access' ) . '</h3>';
+		$output .= '<table>';
+
+		foreach ( $blogs as $blog ) {
+			$output .= '<tr>';
+			$output .= "<td>{$blog->blogname}</td>";
+			$output .= '<td><a href="' . esc_url( get_admin_url( $blog->userblog_id ) ) . '">' . __( 'Visit Dashboard', 'restricted-site-access' ) . '</a> | ' .
+					   '<a href="' . esc_url( get_home_url( $blog->userblog_id ) ) . '">' . __( 'View Site', 'restricted-site-access' ) . '</a></td>';
+			$output .= '</tr>';
+		}
+
+		$output .= '</table>';
+
+		wp_die( $output, 403 );
 	}
 
 	/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -491,7 +491,7 @@ class Restricted_Site_Access {
 
 		$output .= '</table>';
 
-		wp_die( wp_kses_post( $output ), 403 ); // @codingStandardsIgnoreLine All content already escaped.
+		wp_die( wp_kses_post( $output ), 403 );
 	}
 
 	/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -485,7 +485,7 @@ class Restricted_Site_Access {
 			$output .= '<tr>';
 			$output .= '<td>' . esc_html( $blog->blogname ) . '</td>';
 			$output .= '<td><a href="' . esc_url( get_admin_url( $blog->userblog_id ) ) . '">' . esc_html__( 'Visit Dashboard', 'restricted-site-access' ) . '</a> | ' .
-					'<a href="' . esc_url( get_home_url( $blog->userblog_id ) ) . '">' . esc_html__( 'View Site', 'restricted-site-access' ) . '</a></td>';
+					'<a href="' . esc_url( $blog->siteurl ) . '">' . esc_html__( 'View Site', 'restricted-site-access' ) . '</a></td>';
 			$output .= '</tr>';
 		}
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -452,11 +452,11 @@ class Restricted_Site_Access {
 	 * This method borrows from core's _access_denied_splash() for multi-site installs.
 	 */
 	public static function validate_blog_access() {
-	    if ( ! is_multisite() || ! is_user_logged_in() ) {
-	    	return;
-	    }
+		if ( ! is_multisite() || ! is_user_logged_in() ) {
+			return;
+		}
 
-	    if ( is_user_member_of_blog() || is_network_admin() ) {
+		if ( is_user_member_of_blog() || is_network_admin() ) {
 			return;
 		}
 
@@ -471,27 +471,27 @@ class Restricted_Site_Access {
 
 		if ( empty( $blogs ) ) {
 			// Translators: %1$s: The site name.
-			wp_die( sprintf( __( 'You attempted to access the "%1$s" site, but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ), 403 );
+			wp_die( sprintf( esc_html__( 'You attempted to access the "%1$s" site, but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ), 403 );
 		}
 
 		// Translators: %1$s: The site name.
-		$output  = '<p>' . sprintf( __( 'You attempted to access the "%1$s", but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ) . '</p>';
-		$output .= '<p>' . __( 'If you reached this screen by accident and meant to visit one of your own sites, here are some shortcuts to help you find your way.', 'restricted-site-access' ) . '</p>';
+		$output  = '<p>' . sprintf( esc_html__( 'You attempted to access the "%1$s", but you do not currently have privileges on this site. If you believe you should be able to access the "%1$s" dashboard, please contact your network administrator.', 'restricted-site-access' ), $blog_name ) . '</p>';
+		$output .= '<p>' . esc_html__( 'If you reached this screen by accident and meant to visit one of your own sites, here are some shortcuts to help you find your way.', 'restricted-site-access' ) . '</p>';
 
-		$output .= '<h3>' . __( 'Your Sites', 'restricted-site-access' ) . '</h3>';
+		$output .= '<h3>' . esc_html__( 'Your Sites', 'restricted-site-access' ) . '</h3>';
 		$output .= '<table>';
 
 		foreach ( $blogs as $blog ) {
 			$output .= '<tr>';
-			$output .= "<td>{$blog->blogname}</td>";
-			$output .= '<td><a href="' . esc_url( get_admin_url( $blog->userblog_id ) ) . '">' . __( 'Visit Dashboard', 'restricted-site-access' ) . '</a> | ' .
-					   '<a href="' . esc_url( get_home_url( $blog->userblog_id ) ) . '">' . __( 'View Site', 'restricted-site-access' ) . '</a></td>';
+			$output .= '<td>' . esc_html( $blog_name ) . '</td>';
+			$output .= '<td><a href="' . esc_url( get_admin_url( $blog->userblog_id ) ) . '">' . esc_html__( 'Visit Dashboard', 'restricted-site-access' ) . '</a> | ' .
+					'<a href="' . esc_url( get_home_url( $blog->userblog_id ) ) . '">' . esc_html__( 'View Site', 'restricted-site-access' ) . '</a></td>';
 			$output .= '</tr>';
 		}
 
 		$output .= '</table>';
 
-		wp_die( $output, 403 );
+		wp_die( $output, 403 ); // @codingStandardsIgnoreLine All content already escaped.
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
This adds an additional check for `approach 1` or more specifically `Send them to the WordPress login screen` under the `Handle Restricted Visitors` setting. If multisite users are not given a role on a Subsite which has RSA activated, they are sent into a redirect loop. See #39 for more information.

### Alternate Designs
I had considered the suggested approach in the other ticket ( using the reauth flag ) however, that might have confused the user as it didn't provide any additional information as to why they would have to login again.

### Benefits
Users are now provided a message and links to the blogs they are a part of. This leverages WordPress core code from the `_access_denied_splash()` function with a bit of the wording changed. Except this now works for the front-end as well.

### Possible Drawbacks
None

### Verification Process
1. Create a multisite installation.
1. Enable RSA and setup to restrict logins and redirect users to login.
1. Set RSA to enforce network settings
1. Add a second site
1. Add an administrator to the main site ( not a super admin )
1. Log into the one site the admin has the account on with their account.
1. Attempt to go to site 2 where user has no access but RSA is enabled.
1. Ensure the new message is shown.
1. Ensure admin has dashboard access to the main site.

Screencast of the message:
[![Screenshot from Gyazo](https://gyazo.com/d6562c66051bba65198ab99a4ee67b4f/raw)](https://gyazo.com/d6562c66051bba65198ab99a4ee67b4f)

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests passed.

> No unit tests were needed to implement this but I can definitely oblige if need be.

### Applicable Issues
#39 
