### PR TITLE
Fix escaped html in cache notice

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -786,7 +786,7 @@ class Restricted_Site_Access {
 							sprintf(
 								/* translators: %s: https://wordpress.org/plugins/restricted-site-access/#faq */
 								__( 'Page caching appears to be enabled. Restricted Site Access may not work as expected. <a href="%s">Learn more</a>.' ),
-								'https://wordpress.org/plugins/restricted-site-access/#faq'
+								__( 'https://wordpress.org/plugins/restricted-site-access/#faq', 'restricted-site-access' )
 							)
 						);
 					?>

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -780,7 +780,14 @@ class Restricted_Site_Access {
 			?>
 			<div data-rsa-notice="page-cache" class="notice notice-error is-dismissible">
 				<p>
-					<strong><?php esc_html_e( 'Page caching appears to be enabled. Restricted Site Access may not work as expected. <a href="https://wordpress.org/plugins/restricted-site-access/#faq">Learn more</a>.', 'restricted-site-access' ); ?></strong>
+					<strong><?php
+						echo wp_kses_post(
+							sprintf( '%s <a href="https://wordpress.org/plugins/restricted-site-access/#faq">%s</a>.',
+								__( 'Page caching appears to be enabled. Restricted Site Access may not work as expected.', 'restricted-site-access' ),
+								__( 'Learn more', 'restricted-site-access' )
+							)
+						); ?>
+					</strong>
 				</p>
 			</div>
 			<?php

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -785,7 +785,7 @@ class Restricted_Site_Access {
 						echo wp_kses_post(
 							sprintf(
 								/* translators: %s: https://wordpress.org/plugins/restricted-site-access/#faq */
-								__( 'Page caching appears to be enabled. Restricted Site Access may not work as expected. <a href="%s">Learn more</a>.' ),
+								__( 'Page caching appears to be enabled. Restricted Site Access may not work as expected. <a href="%s">Learn more</a>.', 'restricted-site-access' ),
 								__( 'https://wordpress.org/plugins/restricted-site-access/#faq', 'restricted-site-access' )
 							)
 						);

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -780,13 +780,16 @@ class Restricted_Site_Access {
 			?>
 			<div data-rsa-notice="page-cache" class="notice notice-error is-dismissible">
 				<p>
-					<strong><?php
+					<strong>
+					<?php
 						echo wp_kses_post(
-							sprintf( '%s <a href="https://wordpress.org/plugins/restricted-site-access/#faq">%s</a>.',
-								__( 'Page caching appears to be enabled. Restricted Site Access may not work as expected.', 'restricted-site-access' ),
-								__( 'Learn more', 'restricted-site-access' )
+							sprintf(
+								/* translators: %s: https://wordpress.org/plugins/restricted-site-access/#faq */
+								__( 'Page caching appears to be enabled. Restricted Site Access may not work as expected. <a href="%s">Learn more</a>.' ),
+								'https://wordpress.org/plugins/restricted-site-access/#faq'
 							)
-						); ?>
+						);
+					?>
 					</strong>
 				</p>
 			</div>


### PR DESCRIPTION
### Description of the Change

* Use `wp_kses_post` for escaping.
* Remove HTML from translated strings.

Fixes https://github.com/10up/restricted-site-access/issues/92.

### Benefits

No more escaped HTML displaying for this alert.

### Verification Process

* Enable caching and activate the plugin.
* The warning message should appear, the link should work as expected.

![image](https://user-images.githubusercontent.com/2676022/65010246-75a22780-d8cc-11e9-9980-1897a4fd73c8.png)

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
