### PR TITLE
Release version 7.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,9 +11,12 @@
 /composer.json export-ignore
 /composer.lock export-ignore
 /CONTRIBUTING.md export-ignore
+/CREDITS.md export-ignore
 /Gruntfile.js export-ignore
 /LICENSE.md export-ignore
 /package.json export-ignore
 /package-lock.json export-ignore
 /phpunit.xml export-ignore
 /README.md export-ignore
+/run-wpacceptance.sh export-ignore
+/wpacceptance.json export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [Unreleased]
 
 ## [7.2.0] - TBD
+### Added
+- Confirmation of network-wide plugin disabling (props [@pereirinha](https://github.com/pereirinha), [@adamsilverstein](https://github.com/adamsilverstein) via [#29](https://github.com/10up/restricted-site-access/pull/29))
+- WP Acceptance tests (props [@dkotter](https://github.com/dkotter), [@adamsilverstein](https://github.com/adamsilverstein) via [#86](https://github.com/10up/restricted-site-access/pull/86))
+
+### Changed
+- GitHub Actions workflow files to YAML format (props [@helen](https://github.com/helen) via [#100](https://github.com/10up/restricted-site-access/pull/100))
+- Header and icon images (props [@jenniferbourn](https://profiles.wordpress.org/jenniferbourn/) via [#91](https://github.com/10up/restricted-site-access/pull/91))
+- WordPress "tested up to" version to 5.2 (props [@adamsilverstein](https://github.com/adamsilverstein) via [#84](https://github.com/10up/restricted-site-access/pull/84))
+
+### Fixed
+- Escaped HTML in page caching notice (props [@adamsilverstein](https://github.com/adamsilverstein), [@aaemnnosttv](https://github.com/aaemnnosttv) via [#99](https://github.com/10up/restricted-site-access/pull/99))
+- Multisite - Redirect loop when logging in as user with no role (props [@JayWood](https://github.com/JayWood), [@adamsilverstein](https://github.com/adamsilverstein), [@roytanck](https://github.com/roytanck), [@helen](https://github.com/helen), [@rmccue](https://github.com/rmccue) via [#98](https://github.com/10up/restricted-site-access/pull/98))
 
 ## [7.1.0] - 2019-04-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,130 +1,141 @@
-# Change Log
+# Changelog
 
-All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
+All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).  Moving forward, this project will (more strictly) adhere to [Semantic Versioning](http://semver.org/).
 
-Moving forward, this project will (more strictly) adhere to [Semantic Versioning](http://semver.org/).
+## [Unreleased]
 
-## [ 7.1.0 ] - 2019-04-11
+## [7.2.0] - TBD
+
+## [7.1.0] - 2019-04-11
 ### Added
-* IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.
-* Add constants to force enable/disable restrictions. Set `RSA_FORCE_RESTRICTION` to `true` to force restriction or `RSA_FORBID_RESTRICTION` to disable restriction. `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTRICTION` if both are set.
+- IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.
+- Add constants to force enable/disable restrictions. Set `RSA_FORCE_RESTRICTION` to `true` to force restriction or `RSA_FORBID_RESTRICTION` to disable restriction. `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTRICTION` if both are set.
 
 ### Fixed
-* Disable individual site settings when network enforced mode is on to avoid confusion about why your settings are not being respected.
-* Correctly load admin JS.
-* Improve coding standards across plugin and introduce continuous integration linting against the WordPress coding standards. Update code to VIP Go coding standards.
+- Disable individual site settings when network enforced mode is on to avoid confusion about why your settings are not being respected.
+- Correctly load admin JS.
+- Improve coding standards across plugin and introduce continuous integration linting against the WordPress coding standards. Update code to VIP Go coding standards.
 
 ### Developers
-* Add unit tests accross plugin. Note that when the `WP_TESTS_DOMAIN` constant is set, plugin redirects are disabled. Only set this constant when running the tests.
-* Deploy plugin from GitHub to WordPress.org using GitHub Actions.
-* Add various GitHub community files.
+- Add unit tests accross plugin. Note that when the `WP_TESTS_DOMAIN` constant is set, plugin redirects are disabled. Only set this constant when running the tests.
+- Deploy plugin from GitHub to WordPress.org using GitHub Actions.
+- Add various GitHub community files.
 
-## [ 7.0.1 ] - 2018-09-06
-* Bug fix: Avoid redirect loop when the unrestricted page is set to be the static front page.
-* Bug fix: Fall back to the login screen if the unrestricted page is no longer published.
+## [7.0.1] - 2018-09-06
+- Bug fix: Avoid redirect loop when the unrestricted page is set to be the static front page.
+- Bug fix: Fall back to the login screen if the unrestricted page is no longer published.
 
-## [ 7.0.0 ] - 2018-08-30
-* Feature: WP-CLI support! 🎉 Try `wp rsa` to get started.
-* Feature: Whitelist IPs via the `RSA_IP_WHITELIST` constant.
-* Feature: Use WordPress.org-provided language packs instead of bundled translations.
-* Bug fix: Restrict "virtual pages" and allow them to be used as the unrestricted page, such as with BuddyPress.
-* Bug fix: Hide settings properly when no published pages exist.
-* Bug fix: Avoid double slashes in asset URLs that can lead to 404 errors.
+## [7.0.0] - 2018-08-30
+- Feature: WP-CLI support! 🎉 Try `wp rsa` to get started.
+- Feature: Whitelist IPs via the `RSA_IP_WHITELIST` constant.
+- Feature: Use WordPress.org-provided language packs instead of bundled translations.
+- Bug fix: Restrict "virtual pages" and allow them to be used as the unrestricted page, such as with BuddyPress.
+- Bug fix: Hide settings properly when no published pages exist.
+- Bug fix: Avoid double slashes in asset URLs that can lead to 404 errors.
 
-## [ 6.2.1 ] - 2018-05-21
-* Bug fix: Don't redirect logged-in users viewing the site in a single site install.
+## [6.2.1] - 2018-05-21
+- Bug fix: Don't redirect logged-in users viewing the site in a single site install.
 
-## [ 6.2.0 ] - 2018-05-18
-* **Functionality change:** Check user's role on a site in multisite before granting permission.
-* Feature: Alter or restore previous user permission checking with the `restricted_site_access_user_can_access` filter.
-* Avoid a fatal due to differing parameter counts for the `restricted_site_access_is_restricted` filter.
+## [6.2.0] - 2018-05-18
+- **Functionality change:** Check user's role on a site in multisite before granting permission.
+- Feature: Alter or restore previous user permission checking with the `restricted_site_access_user_can_access` filter.
+- Avoid a fatal due to differing parameter counts for the `restricted_site_access_is_restricted` filter.
 
-## [ 6.1.0 ] - 2018-02-14
-* Correct a PHP notice when running PHP >= 7.1.
-* Refactor logic for checking ip address is in masked ip range.
+## [6.1.0] - 2018-02-14
+- Correct a PHP notice when running PHP >= 7.1.
+- Refactor logic for checking ip address is in masked ip range.
 
 ## [6.0.2] - 2018-01-29
-* Add a 'restrict_site_access_ip_match' action which fires when an ip match occurs. Enables adding session_start() to the IP check, ensuring Varnish type cache will not cache the request.
+- Add a 'restrict_site_access_ip_match' action which fires when an ip match occurs. Enables adding session_start() to the IP check, ensuring Varnish type cache will not cache the request.
 
 ## [6.0.1] - 2017-06-13
-* When plugin is network activated, don't touch individual blog visiblity settings.
-* When plugin is network deactivated, set all individual blogs to default visibility.
+- When plugin is network activated, don't touch individual blog visiblity settings.
+- When plugin is network deactivated, set all individual blogs to default visibility.
 
 ## [6.0] - 2017-06-12
-* Use Grunt to manage assets.
-* Network settings added for management of entire network visibility settings.
-* Display warning if page caching is enabled.
+- Use Grunt to manage assets.
+- Network settings added for management of entire network visibility settings.
+- Display warning if page caching is enabled.
 
 ## [5.1] - 2014-11-29
-* Under the hood refactoring and clean up for performance and maintainability.
-* Small visual refinements to the settings panel.
+- Under the hood refactoring and clean up for performance and maintainability.
+- Small visual refinements to the settings panel.
 
 ## [5.0.1] - 2013-01-27
-* Does not block user activation page in network mode
+- Does not block user activation page in network mode
 
 ## [5.0] - 2012-11-02
-* WordPress 3.5 compatibility (3.5 eliminated the Privacy settings panel in favor of a refreshed Reading panel)
-* Real validation (on the fly and on save) for IP address entries
-* "Restriction message" now supports simple HTML and is edited using WordPress's simple HTML tag editor
-* A bunch of visual refinements that conform better with WordPress 3.4 and newer (spacing, native "shake" effect on invalid entries just like the login form, etc.)
-* A bunch of under the hood refinements (e.g. playing nicer with current screen Help API)
+- WordPress 3.5 compatibility (3.5 eliminated the Privacy settings panel in favor of a refreshed Reading panel)
+- Real validation (on the fly and on save) for IP address entries
+- "Restriction message" now supports simple HTML and is edited using WordPress's simple HTML tag editor
+- A bunch of visual refinements that conform better with WordPress 3.4 and newer (spacing, native "shake" effect on invalid entries just like the login form, etc.)
+- A bunch of under the hood refinements (e.g. playing nicer with current screen Help API)
 
 ## [4.0] - 2011-07-16
-* New restriction option - show restricted visitor a specified page; use with custom page templates for great for website teasers!
-* Major improvements to settings user interface, including hiding unused fields based on settings, easier selection of restriction type, and cleaner "remove" confirmation for IP address list
-* Performance improvements - catches and blocks restricted visitors earlier in the loading process
-* New filter hooks for other developers: 'restricted_site_access_is_restricted', 'restricted_site_access_approach', 'restricted_site_access_redirect_url', and 'restricted_site_access_head'
-* Localization ready - rough Spanish translation included!
-* Basic support for no JavaScript mode
-* Optimized for PHP 5.2, per new WordPress 3.2 requirements (no longer supports PHP < 5.2.4)
-* Assorted other improvements and optimizations to the code base
+- New restriction option - show restricted visitor a specified page; use with custom page templates for great for website teasers!
+- Major improvements to settings user interface, including hiding unused fields based on settings, easier selection of restriction type, and cleaner "remove" confirmation for IP address list
+- Performance improvements - catches and blocks restricted visitors earlier in the loading process
+- New filter hooks for other developers: 'restricted_site_access_is_restricted', 'restricted_site_access_approach', 'restricted_site_access_redirect_url', and 'restricted_site_access_head'
+- Localization ready - rough Spanish translation included!
+- Basic support for no JavaScript mode
+- Optimized for PHP 5.2, per new WordPress 3.2 requirements (no longer supports PHP < 5.2.4)
+- Assorted other improvements and optimizations to the code base
 
 ## [3.2.1] - 2011-03-25
-* Restored PHP4 compatibility
+- Restored PHP4 compatibility
 
 ## [3.2] - 2011-03-25
-* More meaningful page title in "Display Message" mode (previously WordPress > Error)
-* Code clean up, prevent rare warnings in debug mode
+- More meaningful page title in "Display Message" mode (previously WordPress > Error)
+- Code clean up, prevent rare warnings in debug mode
 
 ## [3.1.1] - 2010-07-17
-* Fixed PHP warning when debugging is enabled and redirect path is not checked
+- Fixed PHP warning when debugging is enabled and redirect path is not checked
 
 ## [3.1] - 2010-07-11
-* New feature: backwards compatibility with PHP < 5.1 (limited testing with earlier versions)
-* Bug fix: disappearing blocked access message text box on configuration page
-* Bug fix: login always redirects visitor back to correct page
-* Improved: built in help on configuration page updated, clearer
-* Improved: "IP already in list" indicator
-* Improved: optimizations to code that handles restriction behavior
+- New feature: backwards compatibility with PHP < 5.1 (limited testing with earlier versions)
+- Bug fix: disappearing blocked access message text box on configuration page
+- Bug fix: login always redirects visitor back to correct page
+- Improved: built in help on configuration page updated, clearer
+- Improved: "IP already in list" indicator
+- Improved: optimizations to code that handles restriction behavior
 
 ## [3.0] - 2010-07-05
-* Integrates with Privacy settings page and site visibility option instead of adding a whole new page
-* Simplified options: clearer instructions, removed unnecessary hiding / showing of some options, fewer lines
-* Indicates whether the site is blocked in the admin next to the site title (WordPress 3.0+ only)
-* New action hook, `restrict_site_access_handling`, allowing developers to add their own restriction handling
-* Cleans up / removes settings when uninstalled
-* Assorted under the hood improvements for best coding practices, sanitization of options, etc
+- Integrates with Privacy settings page and site visibility option instead of adding a whole new page
+- Simplified options: clearer instructions, removed unnecessary hiding / showing of some options, fewer lines
+- Indicates whether the site is blocked in the admin next to the site title (WordPress 3.0+ only)
+- New action hook, `restrict_site_access_handling`, allowing developers to add their own restriction handling
+- Cleans up / removes settings when uninstalled
+- Assorted under the hood improvements for best coding practices, sanitization of options, etc
 
 ## [2.1] - 2010-02-10
-* Customize blocked visitor message
-* Stronger security (patched "search" hole)
-* Better display / handling of blocked visitor message
+- Customize blocked visitor message
+- Stronger security (patched "search" hole)
+- Better display / handling of blocked visitor message
 
 ## [2.0] - 2010-01-10
-* Add support for IP ranges courtesy Eric Buth
-* Major UI changes and improvements; major code improvements
+- Add support for IP ranges courtesy Eric Buth
+- Major UI changes and improvements; major code improvements
 
 ## [1.0.2] - 2009-10-13
-* Fix login redirect to home; improve redirect handling to take advantage of wp_redirect function
+- Fix login redirect to home; improve redirect handling to take advantage of wp_redirect function
 
 ## [1.0.1] - 2009-09-10
-* Important fundamental change related to handling of what should be restricted
+- Important fundamental change related to handling of what should be restricted
 
 ## [1.0] - 2009-08-17
-* Initial public release
-
+- Initial public release
 
 [Unreleased]: https://github.com/10up/restricted-site-access/compare/master...develop
+[7.2.0]: 
+[7.1.0]: 
+[7.0.1]: 
+[7.0.0]: 
+[6.2.1]: 
+[6.2.0]:
+[6.1.0]: 
+[6.0.2]: 
+[6.0.1]: 
+[6.0]: 
 [5.1]: https://github.com/10up/restricted-site-access/compare/5.0.1...5.1
 [5.0.1]: https://github.com/10up/restricted-site-access/compare/5.0...5.0.1
 [5.0]: https://github.com/10up/restricted-site-access/compare/4.0...5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,20 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased]
 
-## [7.2.0] - TBD
+## [7.2.0] - 2019-11-27
 ### Added
-- Confirmation of network-wide plugin disabling (props [@pereirinha](https://github.com/pereirinha), [@adamsilverstein](https://github.com/adamsilverstein) via [#29](https://github.com/10up/restricted-site-access/pull/29))
-- WP Acceptance tests (props [@dkotter](https://github.com/dkotter), [@adamsilverstein](https://github.com/adamsilverstein) via [#86](https://github.com/10up/restricted-site-access/pull/86))
+- Warn and confirm before network disabling the plugin (props [@pereirinha](https://github.com/pereirinha), [@adamsilverstein](https://github.com/adamsilverstein) via [#29](https://github.com/10up/restricted-site-access/pull/29))
+- WP Acceptance integration tests (props [@dkotter](https://github.com/dkotter), [@adamsilverstein](https://github.com/adamsilverstein) via [#86](https://github.com/10up/restricted-site-access/pull/86))
+
+### Fixed
+- Ensure comments associated with IPs stay associated correctly (props [@adamsilverstein](https://github.com/adamsilverstein), [@ivankruchkoff](https://github.com/ivankruchkoff), [@helen](https://github.com/helen) via [#106](https://github.com/10up/restricted-site-access/pull/106))
+- Don't show escaped HTML in page caching notice (props [@adamsilverstein](https://github.com/adamsilverstein), [@aaemnnosttv](https://github.com/aaemnnosttv) via [#99](https://github.com/10up/restricted-site-access/pull/99))
+- Multisite: Avoid a redirect loop when logging in as user with no role (props [@JayWood](https://github.com/JayWood), [@adamsilverstein](https://github.com/adamsilverstein), [@roytanck](https://github.com/roytanck), [@helen](https://github.com/helen), [@rmccue](https://github.com/rmccue) via [#98](https://github.com/10up/restricted-site-access/pull/98))
 
 ### Changed
 - GitHub Actions workflow files to YAML format (props [@helen](https://github.com/helen) via [#100](https://github.com/10up/restricted-site-access/pull/100))
 - Header and icon images (props [@jenniferbourn](https://profiles.wordpress.org/jenniferbourn/) via [#91](https://github.com/10up/restricted-site-access/pull/91))
-- WordPress "tested up to" version to 5.2 (props [@adamsilverstein](https://github.com/adamsilverstein) via [#84](https://github.com/10up/restricted-site-access/pull/84))
-
-### Fixed
-- Escaped HTML in page caching notice (props [@adamsilverstein](https://github.com/adamsilverstein), [@aaemnnosttv](https://github.com/aaemnnosttv) via [#99](https://github.com/10up/restricted-site-access/pull/99))
-- Multisite - Redirect loop when logging in as user with no role (props [@JayWood](https://github.com/JayWood), [@adamsilverstein](https://github.com/adamsilverstein), [@roytanck](https://github.com/roytanck), [@helen](https://github.com/helen), [@rmccue](https://github.com/rmccue) via [#98](https://github.com/10up/restricted-site-access/pull/98))
+- Bump WordPress "tested up to" version (props [@adamsilverstein](https://github.com/adamsilverstein) via [#84](https://github.com/10up/restricted-site-access/pull/84))
 
 ## [7.1.0] - 2019-04-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,18 +125,18 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [1.0] - 2009-08-17
 - Initial public release
 
-[Unreleased]: https://github.com/10up/restricted-site-access/compare/master...develop
-[7.2.0]: 
-[7.1.0]: 
-[7.0.1]: 
-[7.0.0]: 
-[6.2.1]: 
-[6.2.0]:
-[6.1.0]: 
-[6.0.2]: 
-[6.0.1]: 
-[6.0]: 
-[5.1]: https://github.com/10up/restricted-site-access/compare/5.0.1...5.1
+[Unreleased]: https://github.com/10up/restricted-site-access/compare/7.2.0...HEAD
+[7.2.0]: https://github.com/10up/restricted-site-access/compare/7.1.0...7.2.0
+[7.1.0]: https://github.com/10up/restricted-site-access/compare/7.0.1...7.1.0
+[7.0.1]: https://github.com/10up/restricted-site-access/compare/7.0.0...7.0.1
+[7.0.0]: https://github.com/10up/restricted-site-access/compare/6.2.1...7.0.0
+[6.2.1]: https://github.com/10up/restricted-site-access/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/10up/restricted-site-access/compare/6.1.0...6.2.0
+[6.1.0]: https://github.com/10up/restricted-site-access/compare/6.0.2...6.1.0
+[6.0.2]: https://github.com/10up/restricted-site-access/compare/6.0.1...6.0.2
+[6.0.1]: https://github.com/10up/restricted-site-access/compare/6.0...6.0.1
+[6.0]: https://github.com/10up/restricted-site-access/compare/5.1..6.0
+[5.1]: https://github.com/10up/restricted-site-access/compare/5.0.1..5.1
 [5.0.1]: https://github.com/10up/restricted-site-access/compare/5.0...5.0.1
 [5.0]: https://github.com/10up/restricted-site-access/compare/4.0...5.0
 [4.0]: https://github.com/10up/restricted-site-access/compare/3.2.1...4.0
@@ -144,9 +144,9 @@ All notable changes to this project will be documented in this file, per [the Ke
 [3.2]: https://github.com/10up/restricted-site-access/compare/3.1.1...3.2
 [3.1.1]: https://github.com/10up/restricted-site-access/compare/3.1...3.1.1
 [3.1]: https://github.com/10up/restricted-site-access/compare/3.0...3.1
-[3.0]: https://github.com/10up/restricted-site-access/compare/2.1...3.0
-[2.1]: https://github.com/10up/restricted-site-access/compare/2.0...2.1
-[2.0]: https://github.com/10up/restricted-site-access/compare/1.0.2...2.0
-[1.0.2]: https://github.com/10up/restricted-site-access/compare/1.0.1...1.0.2
-[1.0.1]: https://github.com/10up/restricted-site-access/compare/1.0...1.0.1
+[3.0]: https://github.com/10up/restricted-site-access/compare/2.1..3.0
+[2.1]: https://github.com/10up/restricted-site-access/compare/2.0..2.1
+[2.0]: https://github.com/10up/restricted-site-access/compare/1.0.2..2.0
+[1.0.2]: https://github.com/10up/restricted-site-access/compare/1.0.1..1.0.2
+[1.0.1]: https://github.com/10up/restricted-site-access/compare/1.0..1.0.1
 [1.0]: https://github.com/10up/restricted-site-access/releases/tag/1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,119 +10,159 @@ All notable changes to this project will be documented in this file, per [the Ke
 ### Added
 - IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.
 - Add constants to force enable/disable restrictions. Set `RSA_FORCE_RESTRICTION` to `true` to force restriction or `RSA_FORBID_RESTRICTION` to disable restriction. `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTRICTION` if both are set.
+- Unit tests accross plugin. Note that when the `WP_TESTS_DOMAIN` constant is set, plugin redirects are disabled. Only set this constant when running the tests.
+- Deploy plugin from GitHub to WordPress.org using GitHub Actions.
+- Various GitHub community files.
 
 ### Fixed
 - Disable individual site settings when network enforced mode is on to avoid confusion about why your settings are not being respected.
 - Correctly load admin JS.
 - Improve coding standards across plugin and introduce continuous integration linting against the WordPress coding standards. Update code to VIP Go coding standards.
 
-### Developers
-- Add unit tests accross plugin. Note that when the `WP_TESTS_DOMAIN` constant is set, plugin redirects are disabled. Only set this constant when running the tests.
-- Deploy plugin from GitHub to WordPress.org using GitHub Actions.
-- Add various GitHub community files.
-
 ## [7.0.1] - 2018-09-06
-- Bug fix: Avoid redirect loop when the unrestricted page is set to be the static front page.
-- Bug fix: Fall back to the login screen if the unrestricted page is no longer published.
+### Fixed
+- Avoid redirect loop when the unrestricted page is set to be the static front page.
+- Fall back to the login screen if the unrestricted page is no longer published.
 
 ## [7.0.0] - 2018-08-30
-- Feature: WP-CLI support! 🎉 Try `wp rsa` to get started.
-- Feature: Whitelist IPs via the `RSA_IP_WHITELIST` constant.
-- Feature: Use WordPress.org-provided language packs instead of bundled translations.
-- Bug fix: Restrict "virtual pages" and allow them to be used as the unrestricted page, such as with BuddyPress.
-- Bug fix: Hide settings properly when no published pages exist.
-- Bug fix: Avoid double slashes in asset URLs that can lead to 404 errors.
+### Added
+- WP-CLI support! 🎉 Try `wp rsa` to get started.
+- Whitelist IPs via the `RSA_IP_WHITELIST` constant.
+- Use WordPress.org-provided language packs instead of bundled translations.
+
+### Fixed
+- Restrict "virtual pages" and allow them to be used as the unrestricted page, such as with BuddyPress.
+- Hide settings properly when no published pages exist.
+- Avoid double slashes in asset URLs that can lead to 404 errors.
 
 ## [6.2.1] - 2018-05-21
-- Bug fix: Don't redirect logged-in users viewing the site in a single site install.
+### Fixed
+- Don't redirect logged-in users viewing the site in a single site install.
 
 ## [6.2.0] - 2018-05-18
+### Added
+- Alter or restore previous user permission checking with the `restricted_site_access_user_can_access` filter.
+
+### Changed
 - **Functionality change:** Check user's role on a site in multisite before granting permission.
-- Feature: Alter or restore previous user permission checking with the `restricted_site_access_user_can_access` filter.
+
+### Fixed
 - Avoid a fatal due to differing parameter counts for the `restricted_site_access_is_restricted` filter.
 
 ## [6.1.0] - 2018-02-14
+### Changed
 - Correct a PHP notice when running PHP >= 7.1.
 - Refactor logic for checking ip address is in masked ip range.
 
 ## [6.0.2] - 2018-01-29
-- Add a 'restrict_site_access_ip_match' action which fires when an ip match occurs. Enables adding session_start() to the IP check, ensuring Varnish type cache will not cache the request.
+### Added
+- 'restrict_site_access_ip_match' action which fires when an ip match occurs. Enables adding session_start() to the IP check, ensuring Varnish type cache will not cache the request.
 
 ## [6.0.1] - 2017-06-13
+### Changed
 - When plugin is network activated, don't touch individual blog visiblity settings.
 - When plugin is network deactivated, set all individual blogs to default visibility.
 
 ## [6.0] - 2017-06-12
+### Added
 - Use Grunt to manage assets.
 - Network settings added for management of entire network visibility settings.
 - Display warning if page caching is enabled.
 
 ## [5.1] - 2014-11-29
+### Changed
 - Under the hood refactoring and clean up for performance and maintainability.
 - Small visual refinements to the settings panel.
 
 ## [5.0.1] - 2013-01-27
+### Fixed
 - Does not block user activation page in network mode
 
 ## [5.0] - 2012-11-02
+### Added
 - WordPress 3.5 compatibility (3.5 eliminated the Privacy settings panel in favor of a refreshed Reading panel)
+
+### Changed
 - Real validation (on the fly and on save) for IP address entries
 - "Restriction message" now supports simple HTML and is edited using WordPress's simple HTML tag editor
 - A bunch of visual refinements that conform better with WordPress 3.4 and newer (spacing, native "shake" effect on invalid entries just like the login form, etc.)
 - A bunch of under the hood refinements (e.g. playing nicer with current screen Help API)
 
 ## [4.0] - 2011-07-16
+### Added
 - New restriction option - show restricted visitor a specified page; use with custom page templates for great for website teasers!
-- Major improvements to settings user interface, including hiding unused fields based on settings, easier selection of restriction type, and cleaner "remove" confirmation for IP address list
-- Performance improvements - catches and blocks restricted visitors earlier in the loading process
 - New filter hooks for other developers: 'restricted_site_access_is_restricted', 'restricted_site_access_approach', 'restricted_site_access_redirect_url', and 'restricted_site_access_head'
 - Localization ready - rough Spanish translation included!
 - Basic support for no JavaScript mode
+
+### Changed
+- Major improvements to settings user interface, including hiding unused fields based on settings, easier selection of restriction type, and cleaner "remove" confirmation for IP address list
+- Performance improvements - catches and blocks restricted visitors earlier in the loading process
 - Optimized for PHP 5.2, per new WordPress 3.2 requirements (no longer supports PHP < 5.2.4)
 - Assorted other improvements and optimizations to the code base
 
 ## [3.2.1] - 2011-03-25
+### Changed
 - Restored PHP4 compatibility
 
 ## [3.2] - 2011-03-25
+### Changed
 - More meaningful page title in "Display Message" mode (previously WordPress > Error)
 - Code clean up, prevent rare warnings in debug mode
 
 ## [3.1.1] - 2010-07-17
-- Fixed PHP warning when debugging is enabled and redirect path is not checked
+### Fixed
+- PHP warning when debugging is enabled and redirect path is not checked
 
 ## [3.1] - 2010-07-11
-- New feature: backwards compatibility with PHP < 5.1 (limited testing with earlier versions)
-- Bug fix: disappearing blocked access message text box on configuration page
-- Bug fix: login always redirects visitor back to correct page
-- Improved: built in help on configuration page updated, clearer
-- Improved: "IP already in list" indicator
-- Improved: optimizations to code that handles restriction behavior
+### Added
+- Backwards compatibility with PHP < 5.1 (limited testing with earlier versions)
+
+### Changed
+- Built in help on configuration page updated, clearer
+- "IP already in list" indicator
+- Optimizations to code that handles restriction behavior
+
+### Fixed
+- Disappearing blocked access message text box on configuration page
+- Login always redirects visitor back to correct page
 
 ## [3.0] - 2010-07-05
-- Integrates with Privacy settings page and site visibility option instead of adding a whole new page
-- Simplified options: clearer instructions, removed unnecessary hiding / showing of some options, fewer lines
+### Added
 - Indicates whether the site is blocked in the admin next to the site title (WordPress 3.0+ only)
 - New action hook, `restrict_site_access_handling`, allowing developers to add their own restriction handling
+
+### Changed
+- Integrates with Privacy settings page and site visibility option instead of adding a whole new page
+- Simplified options: clearer instructions, removed unnecessary hiding / showing of some options, fewer lines
 - Cleans up / removes settings when uninstalled
 - Assorted under the hood improvements for best coding practices, sanitization of options, etc
 
 ## [2.1] - 2010-02-10
+### Changed
 - Customize blocked visitor message
-- Stronger security (patched "search" hole)
 - Better display / handling of blocked visitor message
 
+### Security
+- Stronger security (patched "search" hole)
+
 ## [2.0] - 2010-01-10
-- Add support for IP ranges courtesy Eric Buth
+### Added
+- Support for IP ranges courtesy Eric Buth
+
+### Changed
 - Major UI changes and improvements; major code improvements
 
 ## [1.0.2] - 2009-10-13
-- Fix login redirect to home; improve redirect handling to take advantage of wp_redirect function
+### Fixed
+- Login redirect to home; improve redirect handling to take advantage of wp_redirect function
 
 ## [1.0.1] - 2009-09-10
+### Changed
 - Important fundamental change related to handling of what should be restricted
 
 ## [1.0] - 2009-08-17
+### Added
 - Initial public release
 
 [Unreleased]: https://github.com/10up/restricted-site-access/compare/7.2.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,14 @@ The `develop` branch is the development branch which means it contains the next 
 
 ## Release instructions
 
-1. Version bump: Bump the version number in `restricted_site_access.php` and `readme.txt`.
-2. Changelog: Add/update the changelog in both `readme.txt` and `CHANGELOG.md`
-3. Readme updates: Make any other readme changes as necessary. `CHANGELOG.md` and `README.md` are geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.
-4. Merge: Make a non-fast-forward merge from `develop` to `master` (`git checkout master && git merge --no-ff develop`).
-5. Release: Create a [new release](https://github.com/10up/restricted-site-access/releases/new), naming the tag and the release with the new version number. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/restricted-site-access/milestone/2?closed=1`). Close the milestone.
-6. SVN: Wait for the [GitHub Action](https://github.com/10up/restricted-site-access/actions) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
+1. Starting from `develop`, cut a release branch named `release/7.2.0` for your changes.
+2. Version bump: Bump the version number in `restricted_site_access.php` and `readme.txt` if it does not already reflect the version being released.
+3. Changelog: Add/update the changelog in both `readme.txt` and `CHANGELOG.md`
+4. Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
+5. Readme updates: Make any other readme changes as necessary. `CHANGELOG.md` and `README.md` are geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.
+6. Merge: Make a non-fast-forward merge from `develop` to `master` (`git checkout master && git merge --no-ff develop`).
+7. Release: Create a [new release](https://github.com/10up/restricted-site-access/releases/new), naming the tag and the release with the new version number. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/restricted-site-access/milestone/2?closed=1`). Close the milestone.
+8. SVN: Wait for the [GitHub Action](https://github.com/10up/restricted-site-access/actions) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
+9. Edit the [7.2.0 milestone](https://github.com/10up/restricted-site-access/milestone/4) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close `7.2.0` milestone.
+10. If any open issues or PRs which were milestoned for `7.2.0` do not make it into the release, update their milestone to `7.3.0` or `Future Release`.
 7. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/restricted-site-access/. This may take a few minutes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The `develop` branch is the development branch which means it contains the next 
 
 ## Release instructions
 
-1. Starting from `develop`, cut a release branch named `release/7.2.0` for your changes.
+1. Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
 2. Version bump: Bump the version number in `restricted_site_access.php` and `readme.txt` if it does not already reflect the version being released.
 3. Changelog: Add/update the changelog in both `readme.txt` and `CHANGELOG.md`
 4. Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
@@ -36,6 +36,6 @@ The `develop` branch is the development branch which means it contains the next 
 6. Merge: Make a non-fast-forward merge from `develop` to `master` (`git checkout master && git merge --no-ff develop`).
 7. Release: Create a [new release](https://github.com/10up/restricted-site-access/releases/new), naming the tag and the release with the new version number. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/restricted-site-access/milestone/2?closed=1`). Close the milestone.
 8. SVN: Wait for the [GitHub Action](https://github.com/10up/restricted-site-access/actions) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
-9. Edit the [7.2.0 milestone](https://github.com/10up/restricted-site-access/milestone/4) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close `7.2.0` milestone.
-10. If any open issues or PRs which were milestoned for `7.2.0` do not make it into the release, update their milestone to `7.3.0` or `Future Release`.
+9. Edit the [X.Y.Z milestone](https://github.com/10up/restricted-site-access/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close `X.Y.Z` milestone.
+10. If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0`, or `Future Release`.
 7. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/restricted-site-access/. This may take a few minutes.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,19 @@
+The following acknowledges the Maintainers for this repository, those who have Contributed to this repository (via bug reports, code, design, ideas, project management, translation, testing, etc.), and any Libraries utilized.
+
+## Maintainers
+
+The following individuals are responsible for curating the list of issues, responding to pull requests, and ensuring regular releases happen.
+
+[Helen Hou-Sandí (@helen)](https://github.com/helen), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul)
+
+## Contributors
+
+Thank you to all the people who have already contributed to this repository via bug reports, code, design, ideas, project management, translation, testing, etc.
+
+[Jake Goldman (@jakemgold)](https://github.com/jakemgold), [Joey Blake (@joeyblake)](https://github.com/joeyblake), [Steve Grunwell (@stevegrunwell)](https://github.com/stevegrunwell), [Grant Mangham (@vancoder)](https://github.com/vancoder), [@jmata-loop](https://github.com/jmata-loop), [Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Ivan Kristianto (@ivankristianto)](https://github.com/ivankristianto), [Mika Epstein (@Ipstenu)](https://github.com/Ipstenu), [Adam Silverstein (@adamsilverstein)](https://github.com/adamsilverstein), [Prasath Nadarajah (@nprasath002)](https://github.com/nprasath002), [@imath](https://github.com/imath), [Ryan Welcher (@ryanwelcher)](https://github.com/ryanwelcher), [Peter Tasker (@ptasker)](https://github.com/ptasker), [Darin Kotter (@dkotter)](https://github.com/dkotter), [Helen Hou-Sandí (@helen)](https://github.com/helen), [Echo (@ChaosExAnima)](https://github.com/ChaosExAnima), [William Patton (@pattonwebz)](https://github.com/pattonwebz), [Oscar Sanchez S. (@oscarssanchez)](https://github.com/oscarssanchez), [Pete Nelson (@petenelson)](https://github.com/petenelson), [Nate Allen (@nate-allen)](https://github.com/nate-allen), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Evan Mattson (@aaemnnosttv)](https://github.com/aaemnnosttv), [@JayWood](https://github.com/JayWood)
+
+## Libraries
+
+The following software libraries are utilized in this repository.
+
+**n/a**

--- a/README.md
+++ b/README.md
@@ -117,9 +117,13 @@ Please note that setting `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTR
 
 **Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
 
+## Changelog
+
+A complete listing of all notable changes to Restricted Site Access are documented in [CHANGELOG.md](https://github.com/10up/restricted-site-access/blob/develop/CHANGELOG.md).
+
 ## Contributing
 
-Please read [CODE_OF_CONDUCT.md](https://github.com/10up/restricted-site-access/blob/develop/CODE_OF_CONDUCT.md) for details on our code of conduct and [CONTRIBUTING.md](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) for details on the process for submitting pull requests to us.
+Please read [CODE_OF_CONDUCT.md](https://github.com/10up/restricted-site-access/blob/develop/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/restricted-site-access/blob/develop/CREDITS.md) for a listing of maintainers of, contributors to, and libraries used by Restricted Site Access.
 
 ## Like what you see?
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Build Status](https://travis-ci.org/10up/restricted-site-access.svg?branch=develop)](https://travis-ci.org/10up/restricted-site-access) [![Release Version](https://img.shields.io/github/release/10up/restricted-site-access.svg)](https://github.com/10up/restricted-site-access/releases/latest)  ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.2%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/restricted-site-access.svg)](https://github.com/10up/restricted-site-access/blob/develop/LICENSE.md)
 
+## Table of Contents  
+* [Features](#features)
+* [Installation](#installation)
+* [FAQs](#frequently-asked-questions)
+  * [Where do I change the restriction settings?](#where-do-i-change-the-restriction-settings)
+  * [It’s not working! My site is wide open!](#its-not-working-my-site-is-wide-open)
+  * [How do I allow access to specific parts of my site?](#how-do-i-allow-access-to-specific-pages-or-parts-of-my-site)
+  * [How secure is this plug-in?](#how-secure-is-this-plug-in)
+  * [Why can't logged-in multisite users see all my sites?](#why-cant-logged-in-users-see-all-the-sites-on-my-multisite-instance)
+  * [Is there a way to configure this with WP-CLI?](#is-there-a-way-to-configure-this-with-wp-cli)
+  * [How can I programmatically define whitelisted IPs?](#how-can-i-programmatically-define-whitelisted-ips)
+  * [Is there a constant to control my site restriction?](#is-there-a-constant-i-can-set-to-ensure-my-site-is-or-is-not-restricted)
+* [Support](#support-level)
+* [Changelog](#changelog)
+* [Contributing](#contributing)
+
 ## Features
 
 Limit access your site to visitors who are logged in or accessing the site from a set of specified IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. A great solution for Extranets, publicly hosted Intranets, or parallel development / staging sites.

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,20 @@ define( 'RSA_IP_WHITELIST', '192.0.0.1|192.0.0.10' );
 
 == Changelog ==
 
+= 7.2.0 =
+**Added**
+* Confirmation of network-wide plugin disabling (props [@pereirinha](profiles.wordpress.org/pereirinha), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* WP Acceptance tests (props [@dkotter](https://profiles.wordpress.org/dkotter/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+
+**Changed**
+* GitHub Actions workflow files to YAML format (props [@helen](https://profiles.wordpress.org/helen/))
+* Header and icon images (props [@jenniferbourn](https://profiles.wordpress.org/jenniferbourn/))
+* WordPress "tested up to" version to 5.2 (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+
+**Fixed**
+* Escaped HTML in page caching notice (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@aaemnnosttv](https://profiles.wordpress.org/aaemnnosttv/))
+* Multisite - Redirect loop when logging in as user with no role (props [@phyrax](https://profiles.wordpress.org/phyrax/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@roytanck](https://profiles.wordpress.org/roytanck/), [@helen](https://profiles.wordpress.org/helen/), [@rmccue](https://profiles.wordpress.org/rmccue/))
+
 = 7.1.0 =
 **Added**
 * IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Restricted Site Access ===
 Contributors: jakemgold, rcbth, 10up, thinkoomph, tlovett1
-Donate link: httsp://10up.com/plugins/restricted-site-access-wordpress/
+Donate link: https://10up.com/plugins/restricted-site-access-wordpress/
 Tags: privacy, restricted, restrict, privacy, limited, permissions, security, block
 Requires at least: 4.6
 Tested up to: 5.2

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Restricted Site Access ===
 Contributors: jakemgold, rcbth, 10up, thinkoomph, tlovett1
-Donate link: http://10up.com/plugins/restricted-site-access-wordpress/
+Donate link: httsp://10up.com/plugins/restricted-site-access-wordpress/
 Tags: privacy, restricted, restrict, privacy, limited, permissions, security, block
 Requires at least: 4.6
 Tested up to: 5.2
-Stable tag: 7.1.0
+Stable tag: 7.2.0
 
 Limit access to visitors who are logged in or allowed by IP addresses. Includes many options for handling blocked visitors.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jakemgold, rcbth, 10up, thinkoomph, tlovett1
 Donate link: https://10up.com/plugins/restricted-site-access-wordpress/
 Tags: privacy, restricted, restrict, privacy, limited, permissions, security, block
 Requires at least: 4.6
-Tested up to: 5.2
+Tested up to: 5.3
 Stable tag: 7.2.0
 
 Limit access to visitors who are logged in or allowed by IP addresses. Includes many options for handling blocked visitors.
@@ -109,13 +109,10 @@ define( 'RSA_IP_WHITELIST', '192.0.0.1|192.0.0.10' );
 == Changelog ==
 
 = 7.2.0 =
-* Added: Confirmation of network-wide plugin disabling (props [@pereirinha](profiles.wordpress.org/pereirinha), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
-* Added: WP Acceptance tests (props [@dkotter](https://profiles.wordpress.org/dkotter/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
-* Changed: GitHub Actions workflow files to YAML format (props [@helen](https://profiles.wordpress.org/helen/))
-* Changed: Header and icon images (props [@jenniferbourn](https://profiles.wordpress.org/jenniferbourn/))
-* Changed: WordPress "tested up to" version to 5.2 (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
-* Fixed: Escaped HTML in page caching notice (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@aaemnnosttv](https://profiles.wordpress.org/aaemnnosttv/))
-* Fixed: Multisite - Redirect loop when logging in as user with no role (props [@phyrax](https://profiles.wordpress.org/phyrax/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@roytanck](https://profiles.wordpress.org/roytanck/), [@helen](https://profiles.wordpress.org/helen/), [@rmccue](https://profiles.wordpress.org/rmccue/))
+* **Added:** Warn and confirm before network disabling the plugin (props [@pereirinha](profiles.wordpress.org/pereirinha), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* **Fixed:** Ensure comments associated with IPs stay associated correctly (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@ivankk](https://profiles.wordpress.org/ivankk/), [@helen](https://profiles.wordpress.org/helen/))
+* **Fixed:** Don't show escaped HTML in page caching notice (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@aaemnnosttv](https://profiles.wordpress.org/aaemnnosttv/))
+* **Fixed:** Multisite: Avoid a redirect loop when logging in as user with no role (props [@phyrax](https://profiles.wordpress.org/phyrax/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@roytanck](https://profiles.wordpress.org/roytanck/), [@helen](https://profiles.wordpress.org/helen/), [@rmccue](https://profiles.wordpress.org/rmccue/))
 
 = 7.1.0 =
 * Added: IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.

--- a/readme.txt
+++ b/readme.txt
@@ -109,33 +109,23 @@ define( 'RSA_IP_WHITELIST', '192.0.0.1|192.0.0.10' );
 == Changelog ==
 
 = 7.2.0 =
-**Added**
-* Confirmation of network-wide plugin disabling (props [@pereirinha](profiles.wordpress.org/pereirinha), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
-* WP Acceptance tests (props [@dkotter](https://profiles.wordpress.org/dkotter/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
-
-**Changed**
-* GitHub Actions workflow files to YAML format (props [@helen](https://profiles.wordpress.org/helen/))
-* Header and icon images (props [@jenniferbourn](https://profiles.wordpress.org/jenniferbourn/))
-* WordPress "tested up to" version to 5.2 (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
-
-**Fixed**
-* Escaped HTML in page caching notice (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@aaemnnosttv](https://profiles.wordpress.org/aaemnnosttv/))
-* Multisite - Redirect loop when logging in as user with no role (props [@phyrax](https://profiles.wordpress.org/phyrax/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@roytanck](https://profiles.wordpress.org/roytanck/), [@helen](https://profiles.wordpress.org/helen/), [@rmccue](https://profiles.wordpress.org/rmccue/))
+* Added: Confirmation of network-wide plugin disabling (props [@pereirinha](profiles.wordpress.org/pereirinha), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* Added: WP Acceptance tests (props [@dkotter](https://profiles.wordpress.org/dkotter/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* Changed: GitHub Actions workflow files to YAML format (props [@helen](https://profiles.wordpress.org/helen/))
+* Changed: Header and icon images (props [@jenniferbourn](https://profiles.wordpress.org/jenniferbourn/))
+* Changed: WordPress "tested up to" version to 5.2 (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* Fixed: Escaped HTML in page caching notice (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@aaemnnosttv](https://profiles.wordpress.org/aaemnnosttv/))
+* Fixed: Multisite - Redirect loop when logging in as user with no role (props [@phyrax](https://profiles.wordpress.org/phyrax/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@roytanck](https://profiles.wordpress.org/roytanck/), [@helen](https://profiles.wordpress.org/helen/), [@rmccue](https://profiles.wordpress.org/rmccue/))
 
 = 7.1.0 =
-**Added**
-* IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.
-* Add constants to force enable/disable restrictions. Set `RSA_FORCE_RESTRICTION` to `true` to force restriction or `RSA_FORBID_RESTRICTION` to disable restriction. `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTRICTION` if both are set.
-
-**Fixed**
-* Disable individual site settings when network enforced mode is on to avoid confusion about why your settings are not being respected.
-* Correctly load admin JS.
-* Improve coding standards across plugin and introduce continuous integration linting against the WordPress coding standards. Update code to VIP Go coding standards.
-
-**Developers**
-* Add unit tests accross plugin. Note that when the `WP_TESTS_DOMAIN` constant is set, plugin redirects are disabled. Only set this constant when running the tests.
-* Deploy plugin from GitHub to WordPress.org using GitHub Actions.
-* Add various GitHub community files.
+* Added: IP whitelist: Add a Comment field next to each IP address to help identify IP addresses added to the whitelist.
+* Added: Add constants to force enable/disable restrictions. Set `RSA_FORCE_RESTRICTION` to `true` to force restriction or `RSA_FORBID_RESTRICTION` to disable restriction. `RSA_FORCE_RESTRICTION` will override `RSA_FORBID_RESTRICTION` if both are set.
+* Fixed: Disable individual site settings when network enforced mode is on to avoid confusion about why your settings are not being respected.
+* Fixed: Correctly load admin JS.
+* Fixed: Improve coding standards across plugin and introduce continuous integration linting against the WordPress coding standards. Update code to VIP Go coding standards.
+* Developers: Add unit tests accross plugin. Note that when the `WP_TESTS_DOMAIN` constant is set, plugin redirects are disabled. Only set this constant when running the tests.
+* Developers: Deploy plugin from GitHub to WordPress.org using GitHub Actions.
+* Developers: Add various GitHub community files.
 
 = 7.0.1 =
 * Bug fix: Avoid redirect loop when the unrestricted page is set to be the static front page.

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1,16 +1,16 @@
 <?php // phpcs:disable WordPress.Files.FileName
 /**
  * Plugin Name: Restricted Site Access
- * Plugin URI: http://10up.com/plugins/restricted-site-access-wordpress/
+ * Plugin URI: https://10up.com/plugins/restricted-site-access-wordpress/
  * Description: <strong>Limit access your site</strong> to visitors who are logged in or accessing the site from a set of specific IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. <strong>Powerful control over redirection</strong>, including <strong>SEO friendly redirect headers</strong>. Great solution for Extranets, publicly hosted Intranets, or parallel development sites.
- * Version: 7.1.0
+ * Version: 7.2.0
  * Author: Jake Goldman, 10up, Oomph
- * Author URI: http://10up.com
+ * Author URI: https://10up.com
  * License: GPLv2 or later
  * Text Domain: restricted-site-access
  */
 
-define( 'RSA_VERSION', '7.1.0' );
+define( 'RSA_VERSION', '7.2.0' );
 
 /**
  * Class responsible for all plugin funcitonality.


### PR DESCRIPTION
PR for tracking changes for the 7.2.0 release.  Target release date: **Monday, September 23rd.**

### [Release steps](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md#release-instructions)

- [x] Starting from `develop`, cut a release branch named `release/7.2.0` for your changes.
- [x] Version bump: Bump the version number in `restricted_site_access.php` and `readme.txt` if it does not already reflect the version being released.
- [x] Changelog: Add/update the changelog in both `readme.txt` and `CHANGELOG.md`.
- [x] Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
- [x] Readme updates: Make any other readme changes as necessary. `CHANGELOG.md` and `README.md` are geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.
- [ ] Merge: Make a non-fast-forward merge from `develop` to `master` (`git checkout master && git merge --no-ff develop`).
- [ ] Release: Create a [new release](https://github.com/10up/restricted-site-access/releases/new), naming the tag and the release with the new version number. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/restricted-site-access/milestone/2?closed=1`). Close the milestone.
- [ ] SVN: Wait for the [GitHub Action](https://github.com/10up/restricted-site-access/actions) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
- [ ] Check WordPress.org: Ensure that the changes are live on [https://wordpress.org/plugins/restricted-site-access/](https://wordpress.org/plugins/restricted-site-access/). This may take a few minutes.
- [ ] Edit the [7.2.0 milestone](https://github.com/10up/restricted-site-access/milestone/4) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close `7.2.0` milestone.
- [ ] If any open issues or PRs which were milestoned for `7.2.0` do not make it into the release, update their milestone to `7.3.0` or `Future Release`.