### PR TITLE
Issue/38/allow more tags in restriction message

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1104,6 +1104,10 @@ class Restricted_Site_Access {
 			self::$rsa_options['message'] = esc_html__( 'Access to this site is restricted.', 'restricted-site-access' );
 		}
 
+		/*
+		 * Removed the 'more' button from quicktags in 7.2.0 and added a filter:
+		 *     'restricted_site_access_message_editor_quicktags'
+		 */
 		wp_editor(
 			self::$rsa_options['message'],
 			'rsa_message',
@@ -1112,6 +1116,12 @@ class Restricted_Site_Access {
 				'textarea_name' => 'rsa_options[message]',
 				'textarea_rows' => 4,
 				'tinymce'       => false,
+				'quicktags'     => apply_filters(
+					'restricted_site_access_message_editor_quicktags',
+					array(
+						'buttons' => 'strong,em,link,block,del,ins,img,ol,ul,li,code,close', // this is default list minus the 'more' tag button.
+					)
+				),
 			)
 		);
 	}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1436,49 +1436,6 @@ class Restricted_Site_Access {
 
 		return $ip;
 	}
-
-	/**
-	 * Returns a list of tags allowed to be used as part of the message passed
-	 * to wp_die() when approach 3 is used. The list is formed from the global
-	 * $allowedtags plus the missing items from quicktags list and a few other
-	 * general tags.
-	 *
-	 * The array is passed through a filter at return:
-	 *     'restricted_site_access_allowed_message_tags'
-	 *
-	 * @method get_allowed_message_tags
-	 * @since  7.2.0
-	 * @return array
-	 */
-	public static function get_allowed_message_tags() {
-		global $allowedtags;
-		return apply_filters(
-			'restricted_site_access_allowed_message_tags',
-			array_merge_recursive(
-				$allowedtags,
-				array(
-					'div'  => array(
-						'class' => true,
-					),
-					'span' => array(
-						'class' => true,
-					),
-					'ins'  => array(
-						'datetime' => true,
-					),
-					'ul'   => array(
-						'class' => true,
-					),
-					'ol'   => array(
-						'class' => true,
-					),
-					'li'   => array(
-						'class' => true,
-					),
-				)
-			)
-		);
-	}
 }
 
 if ( ! defined( 'RSA_IS_NETWORK' ) ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -412,7 +412,7 @@ class Restricted_Site_Access {
 				}
 				// Fall thru to case 3 if case 2 not handled.
 			case 3:
-				$message  = wp_kses_post( self::$rsa_options['message'] );
+				$message  = self::$rsa_options['message'];
 				$message .= "\n<!-- protected by Restricted Site Access http://10up.com/plugins/restricted-site-access-wordpress/ -->";
 				$message  = apply_filters( 'restricted_site_access_message', $message, $wp );
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -990,7 +990,6 @@ class Restricted_Site_Access {
 			$new_input['approach'] = self::$fields['approach']['default'];
 		}
 
-		global $allowedtags;
 		$new_input['message']       = wp_kses( $input['message'] );
 		$new_input['redirect_path'] = empty( $input['redirect_path'] ) ? 0 : 1;
 		$new_input['head_code']     = in_array( (int) $input['head_code'], array( 301, 302, 307 ), true ) ? (int) $input['head_code'] : self::$fields['head_code']['default'];

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -990,7 +990,7 @@ class Restricted_Site_Access {
 			$new_input['approach'] = self::$fields['approach']['default'];
 		}
 
-		$new_input['message']       = wp_kses( $input['message'] );
+		$new_input['message']       = wp_kses_post( $input['message'] );
 		$new_input['redirect_path'] = empty( $input['redirect_path'] ) ? 0 : 1;
 		$new_input['head_code']     = in_array( (int) $input['head_code'], array( 301, 302, 307 ), true ) ? (int) $input['head_code'] : self::$fields['head_code']['default'];
 		$new_input['redirect_url']  = empty( $input['redirect_url'] ) ? '' : esc_url_raw( $input['redirect_url'], array( 'http', 'https' ) );

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -412,7 +412,7 @@ class Restricted_Site_Access {
 				}
 				// Fall thru to case 3 if case 2 not handled.
 			case 3:
-				$message  = wp_kses( self::$rsa_options['message'], self::get_allowed_message_tags() );
+				$message  = wp_kses_post( self::$rsa_options['message'] );
 				$message .= "\n<!-- protected by Restricted Site Access http://10up.com/plugins/restricted-site-access-wordpress/ -->";
 				$message  = apply_filters( 'restricted_site_access_message', $message, $wp );
 
@@ -991,10 +991,7 @@ class Restricted_Site_Access {
 		}
 
 		global $allowedtags;
-		$new_input['message']       = wp_kses(
-			$input['message'],
-			self::get_allowed_message_tags()
-		);
+		$new_input['message']       = wp_kses( $input['message'] );
 		$new_input['redirect_path'] = empty( $input['redirect_path'] ) ? 0 : 1;
 		$new_input['head_code']     = in_array( (int) $input['head_code'], array( 301, 302, 307 ), true ) ? (int) $input['head_code'] : self::$fields['head_code']['default'];
 		$new_input['redirect_url']  = empty( $input['redirect_url'] ) ? '' : esc_url_raw( $input['redirect_url'], array( 'http', 'https' ) );

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -412,7 +412,7 @@ class Restricted_Site_Access {
 				}
 				// Fall thru to case 3 if case 2 not handled.
 			case 3:
-				$message  = esc_html( self::$rsa_options['message'] );
+				$message  = wp_kses( self::$rsa_options['message'], self::get_allowed_message_tags() );
 				$message .= "\n<!-- protected by Restricted Site Access http://10up.com/plugins/restricted-site-access-wordpress/ -->";
 				$message  = apply_filters( 'restricted_site_access_message', $message, $wp );
 
@@ -991,8 +991,10 @@ class Restricted_Site_Access {
 		}
 
 		global $allowedtags;
-		$new_input['message'] = wp_kses( $input['message'], $allowedtags );
-
+		$new_input['message']       = wp_kses(
+			$input['message'],
+			self::get_allowed_message_tags()
+		);
 		$new_input['redirect_path'] = empty( $input['redirect_path'] ) ? 0 : 1;
 		$new_input['head_code']     = in_array( (int) $input['head_code'], array( 301, 302, 307 ), true ) ? (int) $input['head_code'] : self::$fields['head_code']['default'];
 		$new_input['redirect_url']  = empty( $input['redirect_url'] ) ? '' : esc_url_raw( $input['redirect_url'], array( 'http', 'https' ) );
@@ -1441,7 +1443,9 @@ class Restricted_Site_Access {
 
 	/**
 	 * Returns a list of tags allowed to be used as part of the message passed
-	 * in approach 3.
+	 * to wp_die() when approach 3 is used. The list is formed from the global
+	 * $allowedtags plus the missing items from quicktags list and a few other
+	 * general tags.
 	 *
 	 * The array is passed through a filter at return:
 	 *     'restricted_site_access_allowed_message_tags'
@@ -1452,7 +1456,7 @@ class Restricted_Site_Access {
 	 */
 	public static function get_allowed_message_tags() {
 		global $allowedtags;
-		return apply_filiters(
+		return apply_filters(
 			'restricted_site_access_allowed_message_tags',
 			array_merge_recursive(
 				$allowedtags,

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1428,6 +1428,47 @@ class Restricted_Site_Access {
 
 		return $ip;
 	}
+
+	/**
+	 * Returns a list of tags allowed to be used as part of the message passed
+	 * in approach 3.
+	 *
+	 * The array is passed through a filter at return:
+	 *     'restricted_site_access_allowed_message_tags'
+	 *
+	 * @method get_allowed_message_tags
+	 * @since  7.2.0
+	 * @return array
+	 */
+	public static function get_allowed_message_tags() {
+		global $allowedtags;
+		return apply_filiters(
+			'restricted_site_access_allowed_message_tags',
+			array_merge_recursive(
+				$allowedtags,
+				array(
+					'div'  => array(
+						'class' => true,
+					),
+					'span' => array(
+						'class' => true,
+					),
+					'ins'  => array(
+						'datetime' => true,
+					),
+					'ul'   => array(
+						'class' => true,
+					),
+					'ol'   => array(
+						'class' => true,
+					),
+					'li'   => array(
+						'class' => true,
+					),
+				)
+			)
+		);
+	}
 }
 
 if ( ! defined( 'RSA_IS_NETWORK' ) ) {


### PR DESCRIPTION
### Description of the Change

This allows some more html tags to be used in the standard message that is output to disallowed visitors when approach 3 is taken. This is related to issue: #38 

Fixes https://github.com/10up/restricted-site-access/issues/38

I added a static helper method to return a slightly tweaked set of allowable tags. Those tags are:

- `global $allowedtags` 
- `ins`, `ul`, `ol`, `li` (these are the items that are in quicktags toolbar currently but never been in the allowed list)
- `div`, `span` (just useful structural tags people might want)

When the referenced issue was originally opened certain tags were allowable (the standard `global $allowedtags`) however since then better escaping has been added as part of a coding standards pass that sends the message through `esc_html()`.

Currently no html can be rendered when added via the restriction message input.

That input has a quicktags toolbar that lets people input some tags - but those tags won't render due to the escape.

I also modified the tags that are available in the quicktags toolbar to remove the `more` tag button. I feel that button has no value when this message is passed through to `wp_die()`.

### Benefits

This allows users to use a limited subset of html to render as part of their messages. The messages are output to the browser when they hit `wp_die()` that function can accept any html string.

### Possible Drawbacks

It may not be desirable to allow any html to be output here. In that case we probably want to turn off quicktags toolbar.

### Verification Process

Before checking out the code in this PR first visit the setting page and select approach 3. Input some HTML code to the message (and add some using some of the quicktag buttons too) then save the message and log out.

* Visit frontend to see message not rendering html.
* Checkout the code in this PR
* Refresh the page, see html rendered.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

Tests and documentation can be added accordingly if this approach is acceptable.
### Applicable Issues

#38 
