### PR TITLE
Feature/programmatic add remove 96

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ In your `wp-config.php` file, you can define the following:
 define( 'RSA_IP_WHITELIST', '192.0.0.1|192.0.0.10' );
 ```
 
+In 7.1.1, the capacity to programmatically add / remove / set access IPs programmatically was introduced.
+
+The following are valid statements:
+
+Set IPs, ignoring all stored values (but not the constant defined values), if you're going to use the approach with array indices rather than mixing the two.
+```php
+Restricted_Site_Access::set_ips( array( '192.168.0.1', '192.168.0.2', '192.168.0.3' ) );
+Restricted_Site_Access::set_ips( array( 'labelfoo' => '192.168.0.1', 'labelbar' => 192.168.0.2', 'labelbaz' => 192.168.0.3' ) );
+```
+
+Add IPs, if they're not already added.
+```php
+Restricted_Site_Access::add_ips( array( 'five' => '192.168.1.5', 'six' => '192.168.1.6') );
+```
+
+Remove IPs, if they are in the list.
+```php
+Restricted_Site_Access::remove_ips( array( '192.168.1.2','192.168.1.5','192.168.1.6', ) );
+```
+
 ### Is there a constant I can set to ensure my site is (or is not) restricted?
 
 As of version 7.1.0, two constants were introduced that give you the ability to specify if the site should be in restricted mode.

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1448,8 +1448,8 @@ class Restricted_Site_Access {
 			self::$rsa_options = self::get_options();
 		}
 		$ips = (array) $ips;
-		$allowed_ips = (array) self::$rsa_options['allowed'];
-		$comments = (array) self::$rsa_options['comment'];
+		$allowed_ips = isset( $rsa_options['allowed'] ) ? (array) self::$rsa_options['allowed'] : array();
+		$comments = isset( $rsa_options['comment'] ) ? (array) self::$rsa_options['comment'] : array();
 		$i = 0;
 		foreach( $ips as $label => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
@@ -1482,8 +1482,8 @@ class Restricted_Site_Access {
 			if ( is_null( self::$fields ) ) {
 				self::populate_fields_array();
 			}
-			self::$rsa_options = self::get_options();
 		}
+		self::$rsa_options = self::get_options();
 
 		$ips = (array) $ips;
 		$allowed_ips = (array) self::$rsa_options['allowed'];

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://10up.com/plugins/restricted-site-access-wordpress/
  * Description: <strong>Limit access your site</strong> to visitors who are logged in or accessing the site from a set of specific IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. <strong>Powerful control over redirection</strong>, including <strong>SEO friendly redirect headers</strong>. Great solution for Extranets, publicly hosted Intranets, or parallel development sites.
  * Version: 7.1.0
-l* Author: Jake Goldman, 10up, Oomph
+ * Author: Jake Goldman, 10up, Oomph
  * Author URI: http://10up.com
  * License: GPLv2 or later
  * Text Domain: restricted-site-access

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1433,8 +1433,14 @@ class Restricted_Site_Access {
 
 	/**
 	 * Add ips programmatically
+     *
+     * The $ip_list can either contain a single IP via string, IP addresses in an array, e.g.
+     * '192.168.0.1'
+     * array( '192.168.0.1', '192.168.0.2' )
+     * or labels can be used as array indices
+     * array( 'labelone' => '192.168.0.1', 'labeltwo' => '192.168.0.2' )
 	 *
-	 * @param  array $ip_list
+	 * @param  string|array $ip_list
 	 */
 	public static function add_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {
@@ -1466,8 +1472,12 @@ class Restricted_Site_Access {
 
 	/**
 	 * Remove ips programmatically
+     *
+     * The $ip_list can either contain a single IP via string, IP addresses in an array, e.g.
+     * '192.168.0.1'
+     * array( '192.168.0.1', '192.168.0.2' )
 	 *
-	 * @param  array $ip_list
+	 * @param  string|array $ip_list
 	 */
 	public static function remove_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {
@@ -1498,8 +1508,9 @@ class Restricted_Site_Access {
 
 	/**
 	 * Set ips programmatically
+     * Same syntax as add_ips(), but this replaces existing IPs and comments.
 	 *
-	 * @param  array $ip_list
+	 * @param  string|array $ip_list
 	 */
 	public static function set_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1488,7 +1488,7 @@ class Restricted_Site_Access {
 		$comments    = (array) self::$rsa_options['comment'];
 		$found_ips   = array_intersect( $allowed_ips, $ips );
 		foreach ( array_keys( $found_ips ) as $found_ip_key ) {
-			unset( $comments[ $found_ip_key + 1 ] ); // Workaround for #103 off by one on comments.
+			unset( $comments[ $found_ip_key ] );
 			unset( $allowed_ips[ $found_ip_key ] );
 		}
 		$comments    = array_values( $comments );
@@ -1516,7 +1516,7 @@ class Restricted_Site_Access {
 		}
 		$ips         = (array) $ips;
 		$allowed_ips = array();
-		$comments    = array( '' ); // Workaround for https://github.com/10up/restricted-site-access/issues/103.
+		$comments    = array();
 		$i           = 0;
 		foreach ( $ips as $label => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips, true ) && self::is_ip( $ip ) ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://10up.com/plugins/restricted-site-access-wordpress/
  * Description: <strong>Limit access your site</strong> to visitors who are logged in or accessing the site from a set of specific IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. <strong>Powerful control over redirection</strong>, including <strong>SEO friendly redirect headers</strong>. Great solution for Extranets, publicly hosted Intranets, or parallel development sites.
  * Version: 7.1.0
- * Author: Jake Goldman, 10up, Oomph
+l* Author: Jake Goldman, 10up, Oomph
  * Author URI: http://10up.com
  * License: GPLv2 or later
  * Text Domain: restricted-site-access
@@ -213,7 +213,7 @@ class Restricted_Site_Access {
 	/**
 	 * Populate the option with defaults.
 	 *
-	 * @param boolean $network Whther this is a network install. Default false.
+	 * @param boolean $network Whether this is a network install. Default false.
 	 */
 	public static function get_options( $network = false ) {
 		$options = array();
@@ -327,7 +327,9 @@ class Restricted_Site_Access {
 	 * @return array              List of URL and code, otherwise empty.
 	 */
 	public static function restrict_access_check( $wp ) {
-		self::$rsa_options = self::get_options();
+		if ( is_null( self::$rsa_options ) ) {
+			self::$rsa_options = self::get_options();
+		}
 		$is_restricted     = self::is_restricted();
 
 		// Check to see if it's _not_ restricted.
@@ -1427,6 +1429,83 @@ class Restricted_Site_Access {
 		}
 
 		return $ip;
+	}
+
+	/**
+	 * Add ips programmatically
+	 *
+	 * @param  array $ip_list
+	 */
+	public static function add_ips( $ips ) {
+		if ( is_null( self::$rsa_options ) ) {
+			if ( is_null( self::$fields ) ) {
+				self::populate_fields_array();
+			}
+			self::$rsa_options = self::get_options();
+		}
+		$ips = (array) $ips;
+		$allowed_ips = (array) self::$rsa_options['allowed'];
+		foreach( $ips as $ip ) {
+			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
+				$allowed_ips[] = $ip;
+			}
+		}
+
+
+
+		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
+			self::$rsa_options['allowed'] = $allowed_ips;
+			update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
+		}
+	}
+
+	/**
+	 * Remove ips programmatically
+	 *
+	 * @param  array $ip_list
+	 */
+	public static function remove_ips( $ips ) {
+		if ( is_null( self::$rsa_options ) ) {
+			if ( is_null( self::$fields ) ) {
+				self::populate_fields_array();
+			}
+			self::$rsa_options = self::get_options();
+		}
+		$ips = (array) $ips;
+		$allowed_ips = (array) self::$rsa_options['allowed'];
+		$allowed_ips = array_diff( $allowed_ips, $ips );
+
+		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
+			self::$rsa_options['allowed'] = $allowed_ips;
+			update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
+		}
+	}
+
+	/**
+	 * Set ips programmatically
+	 *
+	 * @param  array $ip_list
+	 */
+	public static function set_ips( $ips ) {
+		if ( is_null( self::$rsa_options ) ) {
+			if ( is_null( self::$fields ) ) {
+				self::populate_fields_array();
+			}
+			self::$rsa_options = self::get_options();
+		}
+		$ips = (array) $ips;
+		$allowed_ips = array();
+		foreach( $ips as $ip ) {
+			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
+				$allowed_ips[] = $ip;
+			}
+		}
+
+		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
+			self::$rsa_options['allowed'] = $allowed_ips;
+			update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
+		}
+
 	}
 }
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1445,16 +1445,21 @@ class Restricted_Site_Access {
 		}
 		$ips = (array) $ips;
 		$allowed_ips = (array) self::$rsa_options['allowed'];
-		foreach( $ips as $ip ) {
+		$comments = (array) self::$rsa_options['comment'];
+		$i = 0;
+		foreach( $ips as $label => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
+				$comments[] = $i !== $label ? sanitize_text_field( $label ) : '';
 			}
+			$i++;
 		}
 
 
 
 		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
 			self::$rsa_options['allowed'] = $allowed_ips;
+			self::$rsa_options['comment'] = $comments;
 			update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
 		}
 	}
@@ -1471,12 +1476,22 @@ class Restricted_Site_Access {
 			}
 			self::$rsa_options = self::get_options();
 		}
+
 		$ips = (array) $ips;
 		$allowed_ips = (array) self::$rsa_options['allowed'];
-		$allowed_ips = array_diff( $allowed_ips, $ips );
+		$comments = (array) self::$rsa_options['comment'];
+		$found_ips = array_intersect( $allowed_ips, $ips );
+		foreach( array_keys( $found_ips ) as $found_ip_key ) {
+			unset( $comments[ $found_ip_key + 1 ] ); // Workaround for #103 off by one on comments
+			unset( $allowed_ips[ $found_ip_key ] );
+		}
+		$comments = array_values( $comments );
+		$allowed_ips = array_values( $allowed_ips );
 
-		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
+
+		if ( self::$rsa_options['allowed'] !== $allowed_ips || self::$rsa_options['comment'] !== $comments ) {
 			self::$rsa_options['allowed'] = $allowed_ips;
+			self::$rsa_options['comment'] = $comments;
 			update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
 		}
 	}
@@ -1495,14 +1510,19 @@ class Restricted_Site_Access {
 		}
 		$ips = (array) $ips;
 		$allowed_ips = array();
-		foreach( $ips as $ip ) {
+		$comments = array( '' ); // Workaround for https://github.com/10up/restricted-site-access/issues/103
+		$i = 0;
+		foreach( $ips as $label => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
+				$comments[] = $i !== $label ? sanitize_text_field( $label ) : '';
 			}
+			$i++;
 		}
 
 		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
 			self::$rsa_options['allowed'] = $allowed_ips;
+			self::$rsa_options['comment'] = $comments;
 			update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
 		}
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1433,12 +1433,12 @@ class Restricted_Site_Access {
 
 	/**
 	 * Add ips programmatically
-     *
-     * The $ip_list can either contain a single IP via string, IP addresses in an array, e.g.
-     * '192.168.0.1'
-     * array( '192.168.0.1', '192.168.0.2' )
-     * or labels can be used as array indices
-     * array( 'labelone' => '192.168.0.1', 'labeltwo' => '192.168.0.2' )
+	 *
+	 * The $ip_list can either contain a single IP via string, IP addresses in an array, e.g.
+	 * '192.168.0.1'
+	 * array( '192.168.0.1', '192.168.0.2' )
+	 * or labels can be used as array indices
+	 * array( 'labelone' => '192.168.0.1', 'labeltwo' => '192.168.0.2' )
 	 *
 	 * @param  string|array $ip_list
 	 */
@@ -1472,10 +1472,10 @@ class Restricted_Site_Access {
 
 	/**
 	 * Remove ips programmatically
-     *
-     * The $ip_list can either contain a single IP via string, IP addresses in an array, e.g.
-     * '192.168.0.1'
-     * array( '192.168.0.1', '192.168.0.2' )
+	 *
+	 * The $ip_list can either contain a single IP via string, IP addresses in an array, e.g.
+	 * '192.168.0.1'
+	 * array( '192.168.0.1', '192.168.0.2' )
 	 *
 	 * @param  string|array $ip_list
 	 */
@@ -1508,7 +1508,7 @@ class Restricted_Site_Access {
 
 	/**
 	 * Set ips programmatically
-     * Same syntax as add_ips(), but this replaces existing IPs and comments.
+	 * Same syntax as add_ips(), but this replaces existing IPs and comments.
 	 *
 	 * @param  string|array $ip_list
 	 */

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1438,7 +1438,7 @@ class Restricted_Site_Access {
 	 * or labels can be used as array indices
 	 * array( 'labelone' => '192.168.0.1', 'labeltwo' => '192.168.0.2' )
 	 *
-	 * @param  string|array $ip_list
+	 * @param  string|array $ips list of IPs to add.
 	 */
 	public static function add_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {
@@ -1447,19 +1447,17 @@ class Restricted_Site_Access {
 			}
 			self::$rsa_options = self::get_options();
 		}
-		$ips = (array) $ips;
+		$ips         = (array) $ips;
 		$allowed_ips = isset( $rsa_options['allowed'] ) ? (array) self::$rsa_options['allowed'] : array();
-		$comments = isset( $rsa_options['comment'] ) ? (array) self::$rsa_options['comment'] : array();
-		$i = 0;
-		foreach( $ips as $label => $ip ) {
-			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
+		$comments    = isset( $rsa_options['comment'] ) ? (array) self::$rsa_options['comment'] : array();
+		$i           = 0;
+		foreach ( $ips as $label => $ip ) {
+			if ( ! in_array( $ip, $allowed_ips, true ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
-				$comments[] = $i !== $label ? sanitize_text_field( $label ) : '';
+				$comments[]    = $i !== $label ? sanitize_text_field( $label ) : '';
 			}
 			$i++;
 		}
-
-
 
 		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
 			self::$rsa_options['allowed'] = $allowed_ips;
@@ -1475,7 +1473,7 @@ class Restricted_Site_Access {
 	 * '192.168.0.1'
 	 * array( '192.168.0.1', '192.168.0.2' )
 	 *
-	 * @param  string|array $ip_list
+	 * @param  string|array $ips list of IPs to remove.
 	 */
 	public static function remove_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {
@@ -1485,17 +1483,16 @@ class Restricted_Site_Access {
 		}
 		self::$rsa_options = self::get_options();
 
-		$ips = (array) $ips;
+		$ips         = (array) $ips;
 		$allowed_ips = (array) self::$rsa_options['allowed'];
-		$comments = (array) self::$rsa_options['comment'];
-		$found_ips = array_intersect( $allowed_ips, $ips );
-		foreach( array_keys( $found_ips ) as $found_ip_key ) {
-			unset( $comments[ $found_ip_key + 1 ] ); // Workaround for #103 off by one on comments
+		$comments    = (array) self::$rsa_options['comment'];
+		$found_ips   = array_intersect( $allowed_ips, $ips );
+		foreach ( array_keys( $found_ips ) as $found_ip_key ) {
+			unset( $comments[ $found_ip_key + 1 ] ); // Workaround for #103 off by one on comments.
 			unset( $allowed_ips[ $found_ip_key ] );
 		}
-		$comments = array_values( $comments );
+		$comments    = array_values( $comments );
 		$allowed_ips = array_values( $allowed_ips );
-
 
 		if ( self::$rsa_options['allowed'] !== $allowed_ips || self::$rsa_options['comment'] !== $comments ) {
 			self::$rsa_options['allowed'] = $allowed_ips;
@@ -1508,7 +1505,7 @@ class Restricted_Site_Access {
 	 * Set ips programmatically
 	 * Same syntax as add_ips(), but this replaces existing IPs and comments.
 	 *
-	 * @param  string|array $ip_list
+	 * @param  string|array $ips list of IPs to set as default IPs.
 	 */
 	public static function set_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {
@@ -1517,14 +1514,14 @@ class Restricted_Site_Access {
 			}
 			self::$rsa_options = self::get_options();
 		}
-		$ips = (array) $ips;
+		$ips         = (array) $ips;
 		$allowed_ips = array();
-		$comments = array( '' ); // Workaround for https://github.com/10up/restricted-site-access/issues/103
-		$i = 0;
-		foreach( $ips as $label => $ip ) {
-			if ( ! in_array( $ip, $allowed_ips ) && self::is_ip( $ip ) ) {
+		$comments    = array( '' ); // Workaround for https://github.com/10up/restricted-site-access/issues/103.
+		$i           = 0;
+		foreach ( $ips as $label => $ip ) {
+			if ( ! in_array( $ip, $allowed_ips, true ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
-				$comments[] = $i !== $label ? sanitize_text_field( $label ) : '';
+				$comments[]    = $i !== $label ? sanitize_text_field( $label ) : '';
 			}
 			$i++;
 		}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -327,9 +327,7 @@ class Restricted_Site_Access {
 	 * @return array              List of URL and code, otherwise empty.
 	 */
 	public static function restrict_access_check( $wp ) {
-		if ( is_null( self::$rsa_options ) ) {
-			self::$rsa_options = self::get_options();
-		}
+		self::$rsa_options = self::get_options();
 		$is_restricted     = self::is_restricted();
 
 		// Check to see if it's _not_ restricted.

--- a/tests/php/singlesite/test-restrictions.php
+++ b/tests/php/singlesite/test-restrictions.php
@@ -214,6 +214,28 @@ class Restricted_Site_Access_Test_Singlesite_Restrictions extends WP_UnitTestCas
 		$wp_rewrite->init();
 	}
 
+	public function test_add_remove_set_ips() {
+		$rsa = Restricted_Site_Access::get_instance();
+		$my_ip = '127.0.0.1';
+		$not_my_ip = '10.9.8.7';
+
+		$options = $rsa::get_options();
+		$rsa::set_ips(array()); // Remove all IPs
+		$this->assertEmpty( $options['allowed'] );
+
+		$rsa::add_ips(array( $my_ip, $not_my_ip )); // Add two IPs
+		$options = $rsa::get_options();
+		$this->assertContains( $my_ip, $options['allowed'] );
+
+		$rsa::remove_ips(array( $my_ip )); // Remove one IP
+		$options = $rsa::get_options();
+		$this->assertNotContains( $my_ip, $options['allowed'] );
+
+		$rsa::set_ips(array()); // Remove all IPs
+		$options = $rsa::get_options();
+		$this->assertEmpty( $options['allowed'] );
+	}
+
 	public function test_singlesite_restrict_access_show_them_a_message() {
 
 		$rsa = Restricted_Site_Access::get_instance();


### PR DESCRIPTION

### Description of the Change

Addresses #96 with the following valid calls:

```php
Restricted_Site_Access::add_ips( '192.168.0.1' );
Restricted_Site_Access::add_ips( array( '192.168.0.1', '192.168.0.2' ) );
Restricted_Site_Access::add_ips( array( 'label1' => '192.168.0.1', 'label2' => '192.168.0.2' ) );
Restricted_Site_Access::remove_ips( array( '192.168.0.1', '192.168.0.2' );
Restricted_Site_Access::set_ips( Array $ip_list );
```

Added some documentation with an assumption of the version number where this will be introduced.

Slight change to the comment spec from:
$ip_list = [ '1.1.1.1' => "Fred', '2.2.2.2' => 'Wilma' ];
to 
$ip_list = [ 'Fred' => '1.1.1.1', 'Wilma' => '2.2.2.2' ];

as this avoids having IPs in both array keys and array values, they're always in the values.

Works around #103 

Can be extended by removing the WP cli functionality and replacing it with calls to these functions.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Went through a set of inputs as add/set/remove:
array( 'label1' => '192.168.0.1', 'label2' => '192.168.0.2' ... 192.168.0.100'
adding and removing arbitrary items and ensuring the admin options-reading corresponded to the expected values

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
#96 
#103 (work around this bug, but haven't resolved it in this PR) 