### PR TITLE
Fix: offset

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1061,9 +1061,17 @@ class Restricted_Site_Access {
 			<?php
 			$ips      = (array) self::$rsa_options['allowed'];
 			$comments = isset( self::$rsa_options['comment'] ) ? (array) self::$rsa_options['comment'] : array();
+
+			// Prior to version 7.2.0, the data stored for comments included an extra blank entry, so the comments array
+			// always contained one extra (empty) entry. This was fixed and the following code handles loading data from
+			// previous versions - if the ip and comment counts don't match, we remove the first comment.
+			if ( ( 1 + count( $ips ) ) === ( count( $comments ) ) ) {
+				array_shift( $comments );
+			}
+
 			foreach ( $ips as $key => $ip ) {
-				if ( ! empty( $ip ) ) {
-					echo '<div><input type="text" name="rsa_options[allowed][]" value="' . esc_attr( $ip ) . '" class="ip code" readonly="true" size="20" /> <input type="text" name="rsa_options[comment][]" value="' . ( isset( $comments[ $key + 1 ] ) ? esc_attr( wp_unslash( $comments[ $key + 1 ] ) ) : '' ) . '" size="20" /> <a href="#remove" class="remove_btn">' . esc_html_x( 'Remove', 'remove IP address action', 'restricted-site-access' ) . '</a></div>';
+			if ( ! empty( $ip ) ) {
+					echo '<div><input type="text" name="rsa_options[allowed][]" value="' . esc_attr( $ip ) . '" class="ip code" readonly="true" size="20" /> <input type="text" name="rsa_options[comment][]" value="' . ( isset( $comments[ $key ] ) ? esc_attr( wp_unslash( $comments[ $key ] ) ) : '' ) . '" size="20" /> <a href="#remove" class="remove_btn">' . esc_html_x( 'Remove', 'remove IP address action', 'restricted-site-access' ) . '</a></div>';
 				}
 			}
 			?>

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1006,6 +1006,11 @@ class Restricted_Site_Access {
 		}
 		$new_input['comment'] = array();
 		if ( ! empty( $input['comment'] ) && is_array( $input['comment'] ) ) {
+
+			// The $input['comment'] array always contains an extra element due to the hidden template used to add
+			// new entries which contains a comment dom element.
+			array_shift( $input['comment'] );
+
 			foreach ( $input['comment'] as $comment ) {
 				if ( is_scalar( $comment ) ) {
 					$new_input['comment'][] = sanitize_text_field( $comment );


### PR DESCRIPTION
### Description of the Change

Fixes https://github.com/10up/restricted-site-access/issues/103

* When saving the comments, remove the first blank entry.
* When loading the comments, account for old data where there is an additional (blank) comment, removing it.

### Benefits

Fixes a data issue and prepares us for https://github.com/10up/restricted-site-access/pull/104

### Verification Process

* save some data on the develop branch
* Check the data that is stored in the database:

`wp option get rsa_options`

* Note extra blank entry at head of data
* Visit Settings->Reading
* Note display still looks fine
* Save settings
* Check the database again: note no extra blank comment in the data
* refresh settings page: note display is still correct.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
