### PR TITLE
Fix: Issue 138

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -735,7 +735,7 @@ class Restricted_Site_Access {
 	public static function enqueue_admin_script() {
 		$current_screen = get_current_screen();
 
-		if ( ! empty( $current_screen ) && ! in_array( $current_screen->id, [ 'plugins-network', 'options-reading' ], true ) ) {
+		if ( ! empty( $current_screen ) && ! in_array( $current_screen->id, array( 'plugins-network', 'options-reading' ), true ) ) {
 			return;
 		}
 
@@ -1512,7 +1512,7 @@ class Restricted_Site_Access {
 	public static function get_ips( $include_config = true, $include_labels = false ) {
 		self::$rsa_options = self::get_options();
 		$current_ips       = (array) self::$rsa_options['allowed'];
-		$config_ips        = [];
+		$config_ips        = array();
 
 		if ( $include_labels ) {
 			$labels      = (array) self::$rsa_options['comment'];

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1325,7 +1325,7 @@ class Restricted_Site_Access {
 
 		// Check if constant disallowing restriction is defined.
 		if ( defined( 'RSA_FORBID_RESTRICTION' ) && RSA_FORBID_RESTRICTION === true ) {
-			$value = 1;
+			$value = 0;
 		}
 
 		// Check if constant forcing restriction is defined.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Set the correct value to `site_public` if `RSA_FORBID_RESTRICTION` is defined

### Alternate Designs


### Benefits
Mimic core behavior

### Possible Drawbacks
-

### Verification Process

- Define `RSA_FORBID_RESTRICTION` to true in wp-config.php
- Go to settings>reading and verify the correct option is checked
- Check robots.txt content is correct and matches the same output as when the constant was not defined


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

https://github.com/10up/restricted-site-access/issues/138
