### PR TITLE
feat/136: Add wp-cli option to modify and retrieve the entry labels

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -740,7 +740,7 @@ class Restricted_Site_Access {
 			'rsa-settings',
 			'rsaSettings',
 			array(
-				'nonce'   => wp_create_nonce( 'rsa_admin_nonce' ),
+				'nonce' => wp_create_nonce( 'rsa_admin_nonce' ),
 			)
 		);
 	}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1598,14 +1598,8 @@ class Restricted_Site_Access {
 			self::$rsa_options = self::get_options();
 		}
 
-		$ip_not_defined    = 0;
-		$ip_invalid_format = 1;
-		$ip_already_exists = 2;
-		$ip_not_found      = 3;
-		$update_success    = 4;
-
 		if ( false === $ip ) {
-			return $ip_not_defined;
+			return new WP_Error( 0, __( 'IP argument not found.', 'restricted-site-access' ) );
 		}
 
 		$allowed_ips = (array) self::$rsa_options['allowed'];
@@ -1624,17 +1618,17 @@ class Restricted_Site_Access {
 		}
 
 		/**
-		 * Return status code 3 if `$ip` not found.
+		 * Return if `$ip` not found.
 		 */
 		if ( -1 === $ip_index ) {
-			return $ip_not_found;
+			return new WP_Error( 3, __( "The IP address doesn't exist", 'restricted-site-access' ) );
 		}
 
 		/**
-		 * Return status code 1 if format of `$new_ip` is invalid.
+		 * Return if the format of `$new_ip` is invalid.
 		 */
 		if ( false !== $new_ip && ! self::is_ip( $new_ip ) ) {
-			return $ip_invalid_format;
+			return new WP_Error( 1, __( 'The new IP address format is incorrect.', 'restricted-site-access' ) );
 		}
 
 		/**
@@ -1642,7 +1636,7 @@ class Restricted_Site_Access {
 		 * `$allowed_ips` array.
 		 */
 		if ( in_array( $new_ip, $allowed_ips, true ) ) {
-			return $ip_already_exists;
+			return new WP_Error( 2, __( 'The IP address already exists.', 'restricted-site-access' ) );
 		}
 
 		/**
@@ -1663,7 +1657,7 @@ class Restricted_Site_Access {
 		self::$rsa_options['comment'] = $comments;
 		update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
 
-		return $update_success;
+		return true;
 	}
 
 	/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1599,7 +1599,7 @@ class Restricted_Site_Access {
 		}
 
 		if ( false === $ip ) {
-			return new WP_Error( 0, __( 'IP argument not found.', 'restricted-site-access' ) );
+			return new WP_Error( 'ip_argument_not_found', __( 'IP argument not found.', 'restricted-site-access' ) );
 		}
 
 		$allowed_ips = (array) self::$rsa_options['allowed'];
@@ -1621,14 +1621,14 @@ class Restricted_Site_Access {
 		 * Return if `$ip` not found.
 		 */
 		if ( -1 === $ip_index ) {
-			return new WP_Error( 3, __( "The IP address doesn't exist", 'restricted-site-access' ) );
+			return new WP_Error( 'ip_address_does_not_exist', __( "The IP address doesn't exist.", 'restricted-site-access' ) );
 		}
 
 		/**
 		 * Return if the format of `$new_ip` is invalid.
 		 */
 		if ( false !== $new_ip && ! self::is_ip( $new_ip ) ) {
-			return new WP_Error( 1, __( 'The new IP address format is incorrect.', 'restricted-site-access' ) );
+			return new WP_Error( 'ip_address_is_invalid', __( 'The new IP address format is incorrect.', 'restricted-site-access' ) );
 		}
 
 		/**
@@ -1636,7 +1636,7 @@ class Restricted_Site_Access {
 		 * `$allowed_ips` array.
 		 */
 		if ( in_array( $new_ip, $allowed_ips, true ) ) {
-			return new WP_Error( 2, __( 'The IP address already exists.', 'restricted-site-access' ) );
+			return new WP_Error( 'ip_address_already_exists', __( 'The IP address already exists.', 'restricted-site-access' ) );
 		}
 
 		/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1553,10 +1553,9 @@ class Restricted_Site_Access {
 	 * or labels can be used as array indices
 	 * array( 'labelone' => '192.168.0.1', 'labeltwo' => '192.168.0.2' )
 	 *
-	 * @param  string|array $ips    list of IPs to add.
-	 * @param  array        $labels list of labels corressponding to the IP.
+	 * @param  string|array $ips list of IPs to add.
 	 */
-	public static function add_ips( $ips, $labels = array() ) {
+	public static function add_ips( $ips ) {
 		if ( is_null( self::$rsa_options ) ) {
 			if ( is_null( self::$fields ) ) {
 				self::populate_fields_array();
@@ -1566,12 +1565,13 @@ class Restricted_Site_Access {
 		$ips         = (array) $ips;
 		$allowed_ips = isset( self::$rsa_options['allowed'] ) ? (array) self::$rsa_options['allowed'] : array();
 		$comments    = isset( self::$rsa_options['comment'] ) ? (array) self::$rsa_options['comment'] : array();
-
-		foreach ( $ips as $index => $ip ) {
+		$i           = 0;
+		foreach ( $ips as $label => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips, true ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
-				$comments[]    = sanitize_text_field( $labels[ $index ] );
+				$comments[]    = $i !== $label && false === strpos( $label, '[null]:' ) ? sanitize_text_field( $label ) : '';
 			}
+			$i++;
 		}
 
 		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1569,7 +1569,7 @@ class Restricted_Site_Access {
 		foreach ( $ips as $label => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips, true ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
-				$comments[]    = $i !== $label && false === strpos( $label, '[null]:' ) ? sanitize_text_field( $label ) : '';
+				$comments[]    = $i !== $label ? sanitize_text_field( $label ) : '';
 			}
 			$i++;
 		}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1553,9 +1553,10 @@ class Restricted_Site_Access {
 	 * or labels can be used as array indices
 	 * array( 'labelone' => '192.168.0.1', 'labeltwo' => '192.168.0.2' )
 	 *
-	 * @param  string|array $ips list of IPs to add.
+	 * @param  string|array $ips    list of IPs to add.
+	 * @param  array        $labels list of labels corressponding to the IP.
 	 */
-	public static function add_ips( $ips ) {
+	public static function add_ips( $ips, $labels = array() ) {
 		if ( is_null( self::$rsa_options ) ) {
 			if ( is_null( self::$fields ) ) {
 				self::populate_fields_array();
@@ -1565,13 +1566,12 @@ class Restricted_Site_Access {
 		$ips         = (array) $ips;
 		$allowed_ips = isset( self::$rsa_options['allowed'] ) ? (array) self::$rsa_options['allowed'] : array();
 		$comments    = isset( self::$rsa_options['comment'] ) ? (array) self::$rsa_options['comment'] : array();
-		$i           = 0;
-		foreach ( $ips as $label => $ip ) {
+
+		foreach ( $ips as $index => $ip ) {
 			if ( ! in_array( $ip, $allowed_ips, true ) && self::is_ip( $ip ) ) {
 				$allowed_ips[] = $ip;
-				$comments[]    = $i !== $label ? sanitize_text_field( $label ) : '';
+				$comments[]    = sanitize_text_field( $labels[ $index ] );
 			}
-			$i++;
 		}
 
 		if ( self::$rsa_options['allowed'] !== $allowed_ips ) {
@@ -1598,14 +1598,14 @@ class Restricted_Site_Access {
 			self::$rsa_options = self::get_options();
 		}
 
-		$IP_NOT_DEFINED    = 0;
-		$IP_INVALID_FORMAT = 1;
-		$IP_ALREADY_EXISTS = 2;
-		$IP_NOT_FOUND      = 3;
-		$UPDATE_SUCCESS    = 4;
+		$ip_not_defined    = 0;
+		$ip_invalid_format = 1;
+		$ip_already_exists = 2;
+		$ip_not_found      = 3;
+		$update_success    = 4;
 
 		if ( false === $ip ) {
-			return $IP_NOT_DEFINED;
+			return $ip_not_defined;
 		}
 
 		$allowed_ips = (array) self::$rsa_options['allowed'];
@@ -1627,14 +1627,14 @@ class Restricted_Site_Access {
 		 * Return status code 3 if `$ip` not found.
 		 */
 		if ( -1 === $ip_index ) {
-			return $IP_NOT_FOUND;
+			return $ip_not_found;
 		}
 
 		/**
 		 * Return status code 1 if format of `$new_ip` is invalid.
 		 */
 		if ( false !== $new_ip && ! self::is_ip( $new_ip ) ) {
-			return $IP_INVALID_FORMAT;
+			return $ip_invalid_format;
 		}
 
 		/**
@@ -1642,7 +1642,7 @@ class Restricted_Site_Access {
 		 * `$allowed_ips` array.
 		 */
 		if ( in_array( $new_ip, $allowed_ips, true ) ) {
-			return $IP_ALREADY_EXISTS;
+			return $ip_already_exists;
 		}
 
 		/**
@@ -1663,7 +1663,7 @@ class Restricted_Site_Access {
 		self::$rsa_options['comment'] = $comments;
 		update_option( 'rsa_options', self::sanitize_options( self::$rsa_options ) );
 
-		return $UPDATE_SUCCESS;
+		return $update_success;
 	}
 
 	/**

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -505,6 +505,70 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * <ip>
+	 * : IP address to update.
+	 *
+	 * [--new-ip]
+	 * : The IP address to replace with.
+	 *
+	 * [--new-label]
+	 * : The new label for the IP address.
+	 *
+	 * [--network]
+	 * : Multisite only. Sets configuration for the network as a whole.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Sets IP whitelist to 192.0.0.1.
+	 *    $ wp rsa ip-set 192.0.0.1
+	 *    Success: Updated site IP whitelist to 192.0.0.1.
+	 *
+	 * @subcommand ip-update
+	 *
+	 * @param array $args       List of IPs to set.
+	 * @param array $assoc_args Optional flags.
+	 */
+	public function ip_update( $args, $assoc_args ) {
+		$this->setup( $args, $assoc_args );
+
+		if ( 0 === count( $assoc_args ) ) {
+			\WP_CLI::warning( 'Provide the arguments to update.', 'restricted-site-access' );
+		}
+
+		$valid_ips = array_filter( $args, array( 'Restricted_Site_Access', 'is_ip' ) );
+
+		if ( 0 === count( $valid_ips ) ) {
+			WP_CLI::error( __( 'No valid IP addresses provided.', 'restricted-site-access' ) );
+		}
+
+		$new_ip      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-ip', false );
+		$new_label   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-label', false );
+
+		$status_code = Restricted_Site_Access::update_ip_or_label( $valid_ips[0], $new_ip, $new_label );
+
+		switch ( $status_code ) {
+			case 0:
+				WP_CLI::error( __( 'IP argument not found.', 'restricted-site-access' ) );
+				break;
+			case 1:
+				WP_CLI::error( __( 'The IP address format is incorrect.', 'restricted-site-access' ) );
+				break;
+			case 2:
+				WP_CLI::error( __( 'The IP address already exists', 'restricted-site-access' ) );
+				break;
+			case 4:
+				WP_CLI::success( __( 'Fields correctly updated.', 'restricted-site-access' ) );
+				break;
+			default:
+				break;
+		}
+	}
+
+	/**
+	 * Sets list of IPs to whitelist. Overwrites current settings.
+	 *
+	 * ## OPTIONS
+	 *
 	 * <ip>...
 	 * : List of IP addresses to whitelist.
 	 *

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -541,8 +541,8 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'No valid IP addresses provided.', 'restricted-site-access' ) );
 		}
 
-		$new_ip      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-ip', false );
-		$new_label   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-label', false );
+		$new_ip    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-ip', false );
+		$new_label = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-label', false );
 
 		$status_code = Restricted_Site_Access::update_ip_or_label( $valid_ips[0], $new_ip, $new_label );
 

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -608,9 +608,13 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *    # Updates the label of IP 192.0.0.1 to "New label"
+	 *    # Update the label of IP 192.0.0.1 to "New label"
 	 *    $ wp rsa ip-update 192.0.0.1 --new-label="New label"
-	 *    Success: Updated site IP whitelist to 192.0.0.1.
+	 *    Success: Fields correctly updated.
+	 *
+	 *    # Replace the IP IP 192.0.0.1 to 200.1.2.3
+	 *    $ wp rsa ip-update 192.0.0.1 --new-ip=200.1.2.3
+	 *    Success: Fields correctly updated.
 	 *
 	 * @subcommand ip-update
 	 *

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -618,7 +618,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 	 *
 	 * @subcommand ip-update
 	 *
-	 * @param array $args       List of IPs to set.
+	 * @param array $args       IP to update.
 	 * @param array $assoc_args Optional flags.
 	 */
 	public function ip_update( $args, $assoc_args ) {
@@ -649,7 +649,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			);
 		}
 
-		WP_CLI::success( __( 'Fields correctly updated.', 'restricted-site-access' ) );
+		WP_CLI::success( __( 'IP updated.', 'restricted-site-access' ) );
 	}
 
 	/**

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -556,6 +556,9 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			case 2:
 				WP_CLI::error( __( 'The IP address already exists', 'restricted-site-access' ) );
 				break;
+			case 3:
+				WP_CLI::error( __( "The IP address doesn't exist", 'restricted-site-access' ) );
+				break;
 			case 4:
 				WP_CLI::success( __( 'Fields correctly updated.', 'restricted-site-access' ) );
 				break;

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -420,8 +420,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			/**
 			 * If the IP doesn't have a corressponding label,
 			 * then set label to '[null]:x', where 'x' is an
-			 * integer. This is because multiple IPs can have
-			 * the same label.
+			 * integer.
 			 */
 			if ( ! isset( $fragments[1] ) ) {
 				$fragments[1] = '[null]:' . $index++;

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -392,7 +392,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 		$this->setup( $args, $assoc_args );
 
 		/**
-		 * The input arguments will can be of the form:
+		 * The input arguments can be of the form:
 		 * wp rsa ip-add 8.8.8.8=Google 9.9.9.9 1.1.1.1=Cloudflare.
 		 *
 		 * Some input IP addresses may be provided with a label while
@@ -419,8 +419,9 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			$fragments = explode( '=', $item );
 			/**
 			 * If the IP doesn't have a corressponding label,
-			 * then set label to '[null]x', where 'x' is an
-			 * integer.
+			 * then set label to '[null]:x', where 'x' is an
+			 * integer. This is because multiple IPs can have
+			 * the same label.
 			 */
 			if ( ! isset( $fragments[1] ) ) {
 				$fragments[1] = '[null]:' . $index++;
@@ -603,7 +604,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *    # Sets IP whitelist to 192.0.0.1.
-	 *    $ wp rsa ip-set 192.0.0.1
+	 *    $ wp rsa ip-update 192.0.0.1
 	 *    Success: Updated site IP whitelist to 192.0.0.1.
 	 *
 	 * @subcommand ip-update
@@ -615,7 +616,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 		$this->setup( $args, $assoc_args );
 
 		if ( 0 === count( $assoc_args ) ) {
-			\WP_CLI::warning( 'Provide the arguments to update.', 'restricted-site-access' );
+			\WP_CLI::warning( __( 'Provide the arguments to update.' ), 'restricted-site-access' );
 		}
 
 		$valid_ips = array_filter( $args, array( 'Restricted_Site_Access', 'is_ip' ) );

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -589,7 +589,8 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 	}
 
 	/**
-	 * Sets list of IPs to whitelist. Overwrites current settings.
+	 * Used to update an existing IP address or to
+	 * update the label of an existing IP address.
 	 *
 	 * ## OPTIONS
 	 *
@@ -607,8 +608,8 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *    # Sets IP whitelist to 192.0.0.1.
-	 *    $ wp rsa ip-update 192.0.0.1
+	 *    # Updates the label of IP 192.0.0.1 to "New label"
+	 *    $ wp rsa ip-update 192.0.0.1 --new-label="New label"
 	 *    Success: Updated site IP whitelist to 192.0.0.1.
 	 *
 	 * @subcommand ip-update
@@ -620,7 +621,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 		$this->setup( $args, $assoc_args );
 
 		if ( 0 === count( $assoc_args ) ) {
-			\WP_CLI::warning( __( 'Provide the arguments to update.' ), 'restricted-site-access' );
+			\WP_CLI::error( __( 'Provide the arguments to update.', 'restricted-site-access' ) );
 		}
 
 		$valid_ips = array_filter( $args, array( 'Restricted_Site_Access', 'is_ip' ) );
@@ -635,7 +636,13 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 		$update_status = Restricted_Site_Access::update_ip_or_label( $valid_ips[0], $new_ip, $new_label );
 
 		if ( is_wp_error( $update_status ) ) {
-			WP_CLI::error( $update_status->get_error_message() );
+			WP_CLI::error(
+				sprintf(
+					'%s (%s)',
+					$update_status->get_error_message(),
+					$update_status->get_error_code()
+				)
+			);
 		}
 
 		WP_CLI::success( __( 'Fields correctly updated.', 'restricted-site-access' ) );

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -628,27 +628,13 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 		$new_ip    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-ip', false );
 		$new_label = \WP_CLI\Utils\get_flag_value( $assoc_args, 'new-label', false );
 
-		$status_code = Restricted_Site_Access::update_ip_or_label( $valid_ips[0], $new_ip, $new_label );
+		$update_status = Restricted_Site_Access::update_ip_or_label( $valid_ips[0], $new_ip, $new_label );
 
-		switch ( $status_code ) {
-			case 0:
-				WP_CLI::error( __( 'IP argument not found.', 'restricted-site-access' ) );
-				break;
-			case 1:
-				WP_CLI::error( __( 'The IP address format is incorrect.', 'restricted-site-access' ) );
-				break;
-			case 2:
-				WP_CLI::error( __( 'The IP address already exists', 'restricted-site-access' ) );
-				break;
-			case 3:
-				WP_CLI::error( __( "The IP address doesn't exist", 'restricted-site-access' ) );
-				break;
-			case 4:
-				WP_CLI::success( __( 'Fields correctly updated.', 'restricted-site-access' ) );
-				break;
-			default:
-				break;
+		if ( is_wp_error( $update_status ) ) {
+			WP_CLI::error( $update_status->get_error_message() );
 		}
+
+		WP_CLI::success( __( 'Fields correctly updated.', 'restricted-site-access' ) );
 	}
 
 	/**

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -423,7 +423,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			 * integer.
 			 */
 			if ( ! isset( $fragments[1] ) ) {
-				$fragments[1] = '[null]:' . $index++;
+				$fragments[1] = '';
 			}
 
 			$structure_ip_label_array = array(
@@ -486,14 +486,19 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			return;
 		}
 
-		$new_ip_label_pairs_structured = array();
+		$ips_with_label    = array();
+		$ips_without_label = array();
 
 		foreach ( $filtered_ips_and_labels as $ip_label_pair ) {
-			$new_ip_label_pairs_structured[ $ip_label_pair['label'] ] = $ip_label_pair['ip'];
+			if ( empty( $ip_label_pair['label'] ) ) {
+				$ips_without_label[] = $ip_label_pair['ip'];
+			} else {
+				$ips_with_label[ $ip_label_pair['label'] ] = $ip_label_pair['ip'];
+			}
 		}
 
 		// Updates the option.
-		Restricted_Site_Access::add_ips( $new_ip_label_pairs_structured );
+		Restricted_Site_Access::add_ips( array_merge( $ips_without_label, $ips_with_label ) );
 
 		WP_CLI::success(
 			sprintf(


### PR DESCRIPTION
Closes #136 
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->
This PR implements points (2) and (3) from the issue. Point (1) is addressed here - https://github.com/10up/restricted-site-access/issues/136#issuecomment-906238894

### 1. Whitelisting IPs through command line with labels
```
wp rsa ip-add 8.8.8.8=Google 9.9.9.9 1.1.1.1=Cloudflare
```
- An IP address without a label works the same way as it did before. An empty string is stored for the label.
- Labels are assigned if the input arguments are of the form `wp rsa ip-add <ip_address>=<label>`.

### 2. Updating an existing IP address
```
wp rsa ip-update 8.8.8.8 --new-ip=8.8.4.4 --new-label="Google Alternate DNS"
```
The format of the command is: `wp rsa ip-update <ip_address_to_update> --new-ip=<new_ip_address> --new-label=<new_label>`

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

