### PR TITLE
fix: WP_TESTS_DOMAIN issue

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -102,7 +102,7 @@ class Restricted_Site_Access {
 	public static function ajax_notice_dismiss() {
 
 		// @codeCoverageIgnoreStart
-		if ( ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
+		if ( ! defined( 'PHP_UNIT_TESTS_ENV' ) ) {
 			if ( ! check_ajax_referer( 'rsa_admin_nonce', 'nonce', false ) ) {
 				wp_send_json_error();
 				exit;
@@ -128,7 +128,7 @@ class Restricted_Site_Access {
 		}
 
 		// @codeCoverageIgnoreStart
-		if ( ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
+		if ( ! defined( 'PHP_UNIT_TESTS_ENV' ) ) {
 			wp_send_json_success();
 		}
 		// @codeCoverageIgnoreEnd
@@ -312,13 +312,13 @@ class Restricted_Site_Access {
 		if ( is_array( $results ) && ! empty( $results ) ) {
 
 			// Don't redirect during unit tests.
-			if ( ! empty( $results['url'] ) && ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
+			if ( ! empty( $results['url'] ) && ! defined( 'PHP_UNIT_TESTS_ENV' ) ) {
 				wp_redirect( $results['url'], $results['code'] ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 				die();
 			}
 
 			// Don't die during unit tests.
-			if ( ! empty( $results['die_message'] ) && ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
+			if ( ! empty( $results['die_message'] ) && ! defined( 'PHP_UNIT_TESTS_ENV' ) ) {
 				wp_die( wp_kses_post( $results['die_message'] ), esc_html( $results['die_title'] ), array( 'response' => esc_html( $results['die_code'] ) ) );
 			}
 		}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -102,7 +102,7 @@ class Restricted_Site_Access {
 	public static function ajax_notice_dismiss() {
 
 		// @codeCoverageIgnoreStart
-		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+		if ( ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
 			if ( ! check_ajax_referer( 'rsa_admin_nonce', 'nonce', false ) ) {
 				wp_send_json_error();
 				exit;
@@ -128,7 +128,7 @@ class Restricted_Site_Access {
 		}
 
 		// @codeCoverageIgnoreStart
-		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+		if ( ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
 			wp_send_json_success();
 		}
 		// @codeCoverageIgnoreEnd
@@ -312,13 +312,13 @@ class Restricted_Site_Access {
 		if ( is_array( $results ) && ! empty( $results ) ) {
 
 			// Don't redirect during unit tests.
-			if ( ! empty( $results['url'] ) && ! defined( 'WP_TESTS_DOMAIN' ) ) {
+			if ( ! empty( $results['url'] ) && ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
 				wp_redirect( $results['url'], $results['code'] ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 				die();
 			}
 
 			// Don't die during unit tests.
-			if ( ! empty( $results['die_message'] ) && ! defined( 'WP_TESTS_DOMAIN' ) ) {
+			if ( ! empty( $results['die_message'] ) && ! defined( 'WP_PHP_TESTS_DOMAIN' ) ) {
 				wp_die( wp_kses_post( $results['die_message'] ), esc_html( $results['die_title'] ), array( 'response' => esc_html( $results['die_code'] ) ) );
 			}
 		}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -60,7 +60,7 @@ class Restricted_Site_Access_Tests_Bootstrap {
 	public function manually_load_plugin() {
 		require $this->plugin_root . '/restricted_site_access.php';
 		define( 'RSA_TEST_PLUGIN_BASENAME', plugin_basename( 'restricted_site_access.php' ) );
-		define( 'WP_PHP_TESTS_DOMAIN', true );
+		define( 'PHP_UNIT_TESTS_ENV', true );
 	}
 }
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -60,6 +60,7 @@ class Restricted_Site_Access_Tests_Bootstrap {
 	public function manually_load_plugin() {
 		require $this->plugin_root . '/restricted_site_access.php';
 		define( 'RSA_TEST_PLUGIN_BASENAME', plugin_basename( 'restricted_site_access.php' ) );
+		define( 'WP_PHP_TESTS_DOMAIN', true );
 	}
 }
 


### PR DESCRIPTION
### Description of the Change

Closes #157 

The default constant `WP_TESTS_DOMAIN` is replaced by a new constant `W̶P̶_̶P̶H̶P̶_̶T̶E̶S̶T̶S̶_̶D̶O̶M̶A̶I̶N̶` `PHP_UNIT_TESTS_ENV`.

### Benefits

It will allow testing correct redirections for restricted users in RSA plugin by Cypress E2E tests.

### Verification Process

Run tests and check if the `restrict_access` [function](https://github.com/10up/restricted-site-access/blob/develop/restricted_site_access.php#L315-L323) runs with correct redirection.

