### PR TITLE
Fix 'Redirect to same path' setting screen-reader-text

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1213,7 +1213,8 @@ class Restricted_Site_Access {
 			// @codeCoverageIgnoreEnd
 		}
 		?>
-		<fieldset><legend class="screen-reader-text"><span><?php esc_html( self::$fields['redirect_path']['label'] ); ?></span></legend>
+		<fieldset>
+			<legend class="screen-reader-text"><span><?php esc_html_e( 'Redirect to same path', 'restricted-site-access' ); ?></span></legend>
 			<label for="redirect_path">
 				<input type="checkbox" name="rsa_options[redirect_path]" value="1" id="redirect_path" class="rsa_redirect_field" <?php checked( self::$rsa_options['redirect_path'] ); ?> />
 				<?php esc_html_e( 'Send restricted visitor to same path (relative URL) at the new web address', 'restricted-site-access' ); ?></label>


### PR DESCRIPTION
### Description of the Change

Fix missing screen-reader-text on setting 'Redirect to same path' being obtained from a non-existing setting array.
Fixes #167 

### Alternate Designs
The method to populate the default settings only passes the field values, not the labels.
So, for now, this PR sets the label as all other fields, hardcoded and duplicating the label.
In the future this could be improved to avoid duplication of this label strings.

### Benefits
Fix PHP error and setting screen reader text.

### Possible Drawbacks
None

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

