### PR TITLE
test/164: check restricted notice page and plugin activation/deactivation

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -38,3 +38,13 @@ jobs:
 
     - name: Test
       run: npm run cypress:run
+
+    - name: Get working directory
+      run: pwd
+
+    - name: Upload RSA artifcats
+      uses: actions/upload-artifact@v2.3.0
+      with:
+        name: 'Cypress artifacts'
+        path: tests/cypress/screenshots/
+        if-no-files-found: warn

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,7 +37,7 @@ jobs:
       run: npm run create-pages
 
     - name: Test
-      run: npm run cypress:run
+      run: npm run cypress:run --record
 
     - name: Get working directory
       run: pwd
@@ -47,5 +47,5 @@ jobs:
       if: always()
       with:
         name: 'Cypress artifacts'
-        path: tests/cypress/screenshots/
+        path: tests/cypress/videos/
         if-no-files-found: warn

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,6 +44,7 @@ jobs:
 
     - name: Upload RSA artifcats
       uses: actions/upload-artifact@v2.3.0
+      if: always()
       with:
         name: 'Cypress artifacts'
         path: tests/cypress/screenshots/

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,5 +33,8 @@ jobs:
     - name: Set up WP environment
       run: npm run wp-env start
 
+    - name: Create pages
+      run: npx wp-env run tests-cli "wp post create --post_type=page --post_title='Accessible page' --post_status='publish'" && npx wp-env run tests-cli "wp post create --post_type=page --post_title='Page to redirect' --post_status='publish'"
+
     - name: Test
       run: npm run cypress:run

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
           - {name: 'WP minimum', version: 'WordPress/WordPress#4.6'}
 
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
+          - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
           - {name: 'WP minimum', version: 'WordPress/WordPress#4.6'}
 
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -34,7 +34,7 @@ jobs:
       run: npm run wp-env start
 
     - name: Create pages
-      run: npx wp-env run tests-cli "wp post create --post_type=page --post_title='Accessible page' --post_status='publish'" && npx wp-env run tests-cli "wp post create --post_type=page --post_title='Page to redirect' --post_status='publish'"
+      run: npm run create-pages
 
     - name: Test
       run: npm run cypress:run

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "wp-env": "wp-env",
     "cypress:open": "cypress open --config-file tests/cypress/config.json",
-    "cypress:run": "cypress run --config-file tests/cypress/config.json"
+    "cypress:run": "cypress run --config-file tests/cypress/config.json",
+    "create-pages": "wp-env run tests-cli \"wp post create --post_type=page --post_title='Accessible page' --post_status='publish'\" && wp-env run tests-cli \"wp post create --post_type=page --post_title='Page to redirect' --post_status='publish'\""
   },
   "author": "10up <sales@10up.com>",
   "license": "GPLv2 (or later)",

--- a/tests/cypress/config.json
+++ b/tests/cypress/config.json
@@ -8,6 +8,7 @@
   "supportFile": "tests/cypress/support/index.js",
   "video": false,
   "testFiles": [
+    "rsa-plugin-activation-deactivation",
     "rsa-settings-spec.js",
     "rsa-admin-settings-interaction.js",
     "rsa-add-remove-ip-addresses.js",
@@ -15,6 +16,7 @@
     "rsa-simple-message-settings.js",
     "rsa-redirect-to-login.js",
     "rsa-redirect-to-web-address.js",
-    "rsa-unrestrict-ip.js"
+    "rsa-unrestrict-ip.js",
+    "rsa-unblocked-page.js"
   ]
 }

--- a/tests/cypress/config.json
+++ b/tests/cypress/config.json
@@ -6,7 +6,6 @@
   "videosFolder": "tests/cypress/videos",
   "downloadsFolder": "tests/cypress/downloads",
   "supportFile": "tests/cypress/support/index.js",
-  "video": false,
   "testFiles": [
     "rsa-plugin-activation-deactivation",
     "rsa-settings-spec.js",

--- a/tests/cypress/integration/rsa-plugin-activation-deactivation.js
+++ b/tests/cypress/integration/rsa-plugin-activation-deactivation.js
@@ -1,0 +1,8 @@
+describe( 'Admin can login and make sure plugin is activated', () => {
+	it( 'Can activate plugin if it is deactivated', () => {
+		cy.visitAdminPage( 'plugins.php' );
+		cy.get( '#deactivate-restricted-site-access' ).click();
+		cy.get( '#activate-restricted-site-access' ).click();
+		cy.get( '#deactivate-restricted-site-access' ).should( 'be.visible' );
+	} );
+} );

--- a/tests/cypress/integration/rsa-settings-spec.js
+++ b/tests/cypress/integration/rsa-settings-spec.js
@@ -1,23 +1,4 @@
 describe( 'Plugin admin settings are properly rendered.', () => {
-	before( () => {
-		cy.visitAdminPage( 'post-new.php?post_type=page' );
-		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get( '.editor-post-title__input' ).click().type( 'Accessible page' );
-		cy.get( '.editor-post-publish-panel__toggle' ).click();
-		cy.get( '.editor-post-publish-button' ).click();
-		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
-			'be.visible'
-		);
-
-		cy.visitAdminPage( 'post-new.php?post_type=page' );
-		cy.get( '.editor-post-title__input' ).click().type( 'Page to redirect' );
-		cy.get( '.editor-post-publish-panel__toggle' ).click();
-		cy.get( '.editor-post-publish-button' ).click();
-		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
-			'be.visible'
-		);
-	} );
-
 	it( 'Visit plugin settings.', () => {
 		cy.visitAdminPage( 'options-reading.php' );
 	} );

--- a/tests/cypress/integration/rsa-settings-spec.js
+++ b/tests/cypress/integration/rsa-settings-spec.js
@@ -1,4 +1,23 @@
 describe( 'Plugin admin settings are properly rendered.', () => {
+	before( () => {
+		cy.visitAdminPage( 'post-new.php?post_type=page' );
+		cy.get( 'button[aria-label="Close dialog"]' ).click();
+		cy.get( '#post-title-0' ).click().type( 'Accessible page' );
+		cy.get( '.editor-post-publish-panel__toggle' ).click();
+		cy.get( '.editor-post-publish-button' ).click();
+		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
+			'be.visible'
+		);
+
+		cy.visitAdminPage( 'post-new.php?post_type=page' );
+		cy.get( '#post-title-0' ).click().type( 'Page to redirect' );
+		cy.get( '.editor-post-publish-panel__toggle' ).click();
+		cy.get( '.editor-post-publish-button' ).click();
+		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
+			'be.visible'
+		);
+	} );
+
 	it( 'Visit plugin settings.', () => {
 		cy.visitAdminPage( 'options-reading.php' );
 	} );

--- a/tests/cypress/integration/rsa-settings-spec.js
+++ b/tests/cypress/integration/rsa-settings-spec.js
@@ -2,7 +2,7 @@ describe( 'Plugin admin settings are properly rendered.', () => {
 	before( () => {
 		cy.visitAdminPage( 'post-new.php?post_type=page' );
 		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get( '#post-title-0' ).click().type( 'Accessible page' );
+		cy.get( '.editor-post-title__input' ).click().type( 'Accessible page' );
 		cy.get( '.editor-post-publish-panel__toggle' ).click();
 		cy.get( '.editor-post-publish-button' ).click();
 		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
@@ -10,7 +10,7 @@ describe( 'Plugin admin settings are properly rendered.', () => {
 		);
 
 		cy.visitAdminPage( 'post-new.php?post_type=page' );
-		cy.get( '#post-title-0' ).click().type( 'Page to redirect' );
+		cy.get( '.editor-post-title__input' ).click().type( 'Page to redirect' );
 		cy.get( '.editor-post-publish-panel__toggle' ).click();
 		cy.get( '.editor-post-publish-button' ).click();
 		cy.get( '.components-snackbar', { timeout: 10000 } ).should(

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -26,6 +26,8 @@ describe( 'Show a page to restricted users', () => {
 	} );
 
 	it( 'Unrestricted user should be able to access the site', () => {
+		cy.visitAdminPage( 'options-permalink.php' );
+		cy.visitAdminPage( 'edit.php?post_type=page' );
 		cy.visit( `${ Cypress.config().baseUrl }accessible-page`, {
 			headers: {
 				'X-Forwarded': '193.168.20.30',

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -6,7 +6,7 @@ describe( 'Show a page to restricted users', () => {
 
 		cy.visitAdminPage( 'post-new.php?post_type=page' );
 		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get( '#post-title-1' ).click().type( 'Accessible page' );
+		cy.get( '#post-title-0' ).click().type( 'Accessible page' );
 		cy.get( '.editor-post-publish-panel__toggle' ).click();
 		cy.get( '.editor-post-publish-button' ).click();
 		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
@@ -28,8 +28,7 @@ describe( 'Show a page to restricted users', () => {
 
 	it( 'Show the selected page to restricted users', () => {
 		cy.visitAdminPage( 'post-new.php?post_type=page' );
-		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get( '#post-title-1' ).click().type( 'Page to redirect' );
+		cy.get( '#post-title-0' ).click().type( 'Page to redirect' );
 		cy.get( '.editor-post-publish-panel__toggle' ).click();
 		cy.get( '.editor-post-publish-button' ).click();
 		cy.get( '.components-snackbar', { timeout: 10000 } ).should(

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -11,7 +11,7 @@ describe( 'Show a page to restricted users', () => {
 			failOnStatusCode: false
 		} );
 
-		cy.get( '.wp-die-message' ).contains( 'This is a restricted site. Please contact the admin.' );
+		cy.get( '#error-page' ).contains( 'This is a restricted site. Please contact the admin.' );
 	} );
 
 	it( 'Show the selected page to restricted users', () => {
@@ -48,7 +48,7 @@ describe( 'Show a page to restricted users', () => {
 			}
 		} ).then( ( response ) => {
 			expect( response.status ).to.eq( 200 );
-			expect( response.body ).to.contain( 'page-template-default page' );
+			expect( response.body ).to.contain( 'Accessible page' );
 		} );
 	} );
 } );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -22,6 +22,7 @@ describe( 'Show a page to restricted users', () => {
 		cy.visit( '/', {
 			failOnStatusCode: false,
 		} );
+		cy.screenshot();
 		cy.url().should( 'include', `${ Cypress.config().baseUrl }page-to-redirect` );
 	} );
 
@@ -31,6 +32,7 @@ describe( 'Show a page to restricted users', () => {
 				'X-Forwarded': '193.168.20.30',
 			}
 		} );
+		cy.screenshot();
 		cy.url().should( 'include', `${ Cypress.config().baseUrl }accessible-page` )
 	} );
 } );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -1,0 +1,75 @@
+describe( 'Show a page to restricted users', () => {
+	before( () => {
+		cy.visitAdminPage( 'options-reading.php' );
+		cy.get( '#rsa-unblocked-page' ).check();
+		cy.saveSettings();
+
+		cy.visitAdminPage( 'post-new.php?post_type=page' );
+		cy.get( 'button[aria-label="Close dialog"]' ).click();
+		cy.get( '#post-title-1' ).click().type( 'Accessible page' );
+		cy.get( '.editor-post-publish-panel__toggle' ).click();
+		cy.get( '.editor-post-publish-button' ).click();
+		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
+			'be.visible'
+		);
+
+
+		cy.logout();
+	} );
+
+	it( 'Show a general restricted message if a page is not selected', () => {
+		cy.visit( '/', {
+			failOnStatusCode: false
+		} );
+
+		cy
+			.get( '.wp-die-message' ).contains( 'This is a restricted site. Please contact the admin.' );
+	} );
+
+	it( 'Show the selected page to restricted users', () => {
+		cy.visitAdminPage( 'post-new.php?post_type=page' );
+		cy.get( 'button[aria-label="Close dialog"]' ).click();
+		cy.get( '#post-title-1' ).click().type( 'Page to redirect' );
+		cy.get( '.editor-post-publish-panel__toggle' ).click();
+		cy.get( '.editor-post-publish-button' ).click();
+		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
+			'be.visible'
+		);
+
+		cy.visitAdminPage( 'options-reading.php' );
+		cy.get( '#rsa_page' ).select( 'Page to redirect' );
+		cy.saveSettings();
+		cy.logout();
+		cy.visit( '/' );
+		cy.url().should( 'include', `${ Cypress.config().baseUrl }page-to-redirect` );
+	} );
+
+	it( 'Unrestricted user should be able to access the site', () => {
+		cy.visitAdminPage( 'options-reading.php' );
+		cy
+			.get( '#newip' )
+			.clear()
+			.type( '193.168.20.30' )
+
+		cy
+			.get( '#addip' )
+			.click();
+
+		cy.wait( 800 )
+
+		cy.saveSettings();
+		cy.logout();
+		cy.visit( '/' );
+		cy.request({
+			method: 'GET',
+			url: `${ Cypress.config().baseUrl }accessible-page`,
+			failOnStatusCode: false,
+			headers: {
+				'X-Forwarded': '193.168.20.30',
+			}
+		} ).then( ( response ) => {
+			expect( response.status ).to.eq( 200 );
+			expect( response.body ).to.contain( 'page-template-default page' );
+		} );
+	} );
+} );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -3,7 +3,6 @@ describe( 'Show a page to restricted users', () => {
 		cy.visitAdminPage( 'options-reading.php' );
 		cy.get( '#rsa-unblocked-page' ).check();
 		cy.saveSettings();
-
 		cy.logout();
 	} );
 
@@ -12,8 +11,7 @@ describe( 'Show a page to restricted users', () => {
 			failOnStatusCode: false
 		} );
 
-		cy
-			.get( '.wp-die-message' ).contains( 'This is a restricted site. Please contact the admin.' );
+		cy.get( '.wp-die-message' ).contains( 'This is a restricted site. Please contact the admin.' );
 	} );
 
 	it( 'Show the selected page to restricted users', () => {

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -4,16 +4,6 @@ describe( 'Show a page to restricted users', () => {
 		cy.get( '#rsa-unblocked-page' ).check();
 		cy.saveSettings();
 
-		cy.visitAdminPage( 'post-new.php?post_type=page' );
-		cy.get( 'button[aria-label="Close dialog"]' ).click();
-		cy.get( '#post-title-0' ).click().type( 'Accessible page' );
-		cy.get( '.editor-post-publish-panel__toggle' ).click();
-		cy.get( '.editor-post-publish-button' ).click();
-		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
-			'be.visible'
-		);
-
-
 		cy.logout();
 	} );
 
@@ -27,14 +17,6 @@ describe( 'Show a page to restricted users', () => {
 	} );
 
 	it( 'Show the selected page to restricted users', () => {
-		cy.visitAdminPage( 'post-new.php?post_type=page' );
-		cy.get( '#post-title-0' ).click().type( 'Page to redirect' );
-		cy.get( '.editor-post-publish-panel__toggle' ).click();
-		cy.get( '.editor-post-publish-button' ).click();
-		cy.get( '.components-snackbar', { timeout: 10000 } ).should(
-			'be.visible'
-		);
-
 		cy.visitAdminPage( 'options-reading.php' );
 		cy.get( '#rsa_page' ).select( 'Page to redirect' );
 		cy.saveSettings();

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -26,29 +26,9 @@ describe( 'Show a page to restricted users', () => {
 	} );
 
 	it( 'Unrestricted user should be able to access the site', () => {
-		cy.visitAdminPage( 'options-reading.php' );
-		cy
-			.get( '#newip' )
-			.clear()
-			.type( '193.168.20.30' )
-
-		cy
-			.get( '#addip' )
-			.click();
-
-		cy.wait( 800 )
-
-		cy.saveSettings();
-		cy.logout();
-		cy.request({
-			method: 'GET',
-			url: `${ Cypress.config().baseUrl }accessible-page`,
-			failOnStatusCode: false,
-			headers: {
-				'X-Forwarded': '193.168.20.30',
-			}
-		} ).then( ( response ) => {
-			expect( response.body ).to.contain( 'Accessible page' );
+		cy.visit( `${ Cypress.config().baseUrl }accessible-page`, {
+			failOnStatusCode: false
 		} );
+		cy.url().should( 'include', `${ Cypress.config().baseUrl }accessible-page` )
 	} );
 } );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -19,7 +19,9 @@ describe( 'Show a page to restricted users', () => {
 		cy.get( '#rsa_page' ).select( 'Page to redirect' );
 		cy.saveSettings();
 		cy.logout();
-		cy.visit( '/' );
+		cy.visit( '/', {
+			failOnStatusCode: false,
+		} );
 		cy.url().should( 'include', `${ Cypress.config().baseUrl }page-to-redirect` );
 	} );
 
@@ -38,7 +40,6 @@ describe( 'Show a page to restricted users', () => {
 
 		cy.saveSettings();
 		cy.logout();
-		cy.visit( '/' );
 		cy.request({
 			method: 'GET',
 			url: `${ Cypress.config().baseUrl }accessible-page`,
@@ -47,7 +48,6 @@ describe( 'Show a page to restricted users', () => {
 				'X-Forwarded': '193.168.20.30',
 			}
 		} ).then( ( response ) => {
-			expect( response.status ).to.eq( 200 );
 			expect( response.body ).to.contain( 'Accessible page' );
 		} );
 	} );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -22,7 +22,6 @@ describe( 'Show a page to restricted users', () => {
 		cy.visit( '/', {
 			failOnStatusCode: false,
 		} );
-		cy.screenshot();
 		cy.url().should( 'include', `${ Cypress.config().baseUrl }page-to-redirect` );
 	} );
 
@@ -32,7 +31,6 @@ describe( 'Show a page to restricted users', () => {
 				'X-Forwarded': '193.168.20.30',
 			}
 		} );
-		cy.screenshot();
 		cy.url().should( 'include', `${ Cypress.config().baseUrl }accessible-page` )
 	} );
 } );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -27,7 +27,9 @@ describe( 'Show a page to restricted users', () => {
 
 	it( 'Unrestricted user should be able to access the site', () => {
 		cy.visit( `${ Cypress.config().baseUrl }accessible-page`, {
-			failOnStatusCode: false
+			headers: {
+				'X-Forwarded': '193.168.20.30',
+			}
 		} );
 		cy.url().should( 'include', `${ Cypress.config().baseUrl }accessible-page` )
 	} );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -26,14 +26,11 @@ describe( 'Show a page to restricted users', () => {
 	} );
 
 	it( 'Unrestricted user should be able to access the site', () => {
-		cy.visitAdminPage( 'options-permalink.php' );
-		cy.visitAdminPage( 'edit.php?post_type=page' );
-		cy.wait( 8000 )
-		cy.visit( `${ Cypress.config().baseUrl }accessible-page`, {
+		cy.visit( `${ Cypress.config().baseUrl }`, {
 			headers: {
 				'X-Forwarded': '193.168.20.30',
 			}
 		} );
-		cy.url().should( 'include', `${ Cypress.config().baseUrl }accessible-page` )
+		cy.contains( 'Hello world!' )
 	} );
 } );

--- a/tests/cypress/integration/rsa-unblocked-page.js
+++ b/tests/cypress/integration/rsa-unblocked-page.js
@@ -28,6 +28,7 @@ describe( 'Show a page to restricted users', () => {
 	it( 'Unrestricted user should be able to access the site', () => {
 		cy.visitAdminPage( 'options-permalink.php' );
 		cy.visitAdminPage( 'edit.php?post_type=page' );
+		cy.wait( 8000 )
 		cy.visit( `${ Cypress.config().baseUrl }accessible-page`, {
 			headers: {
 				'X-Forwarded': '193.168.20.30',


### PR DESCRIPTION
Closes #169 

### Description of the Change
Added the following tests:
- Showing restricted users the "Restricted notice page"
- Plugin activation/deactivation

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
