### PR TITLE
Ensure we load our autoloader from our plugin directory

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -13,7 +13,7 @@
  * Text Domain:       restricted-site-access
  */
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 define( 'RSA_VERSION', '7.3.4' );
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -13,7 +13,32 @@
  * Text Domain:       restricted-site-access
  */
 
-require_once __DIR__ . '/vendor/autoload.php';
+// Try and include our autoloader.
+if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+} elseif ( ! class_exists( 'IPLib\\Factory' ) ) {
+	add_action(
+		'admin_notices',
+		function() {
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %1$s is the command that needs to be run. */
+							__( 'You appear to be running a development version of Restricted Site Access. Please run %1$s in order for things to work properly.', 'restricted-site-access' ),
+							'<code>composer install</code>'
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	);
+	return;
+}
 
 define( 'RSA_VERSION', '7.3.4' );
 


### PR DESCRIPTION
### Description of the Change

In #217 a new composer dependency was added and to ensure it gets loaded, a composer autoloader was required. This was loaded with a `require_once` statement that just referenced the `vendor` directory.

The problem here is that we weren't specifically referencing the directory we should load from. This can result in the autoloader being loaded from somewhere else. For instance, if you have an autoloader at the root of your site (say you use composer to manage all your plugins), this autoloader will be loaded instead in certain situations, causing fatal errors since the dependency we expect is now not loaded.

This PR fixes this by adding the `__DIR__` constant before the file path, ensuring the autoloader is loaded from the root directory of this plugin. We also output an admin notice if that autoloader isn't found and if the base Factory class doesn't exist. This should only be those that are running this plugin directly from GitHub and need to run `composer install`

### Alternate Designs

Could use `plugin_dir_path( __FILE__ )` instead of `__DIR__` but they both return the same value and my preference is the latter.

### Benefits

The correct autoloader is always used

### Possible Drawbacks

None

### Verification Process

Before checking this PR out, add a composer autoloader to the root of your WordPress install (something like `wordpress/vendor/autoload.php`).

Setup Restricted Site Access, add one dummy IP address that is allowed and then try and access the site from an incognito window (seems like the issue happens only if you're not logged into WordPress).

You should get a fatal error.

Then check out the code from this PR and run the same tests again.

Things should work now

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/restricted-site-access/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Fixed - Ensure we load our autoloader from the root of our plugin directory
> Added - Show an admin notice if our autoloader doesn't exist

### Credits

Props @dkotter, @pablojmarti, @shahzaib10up

### Applicable Issues

Closes #229 