### PR TITLE
Add WordPress application password support

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -141,12 +141,14 @@ class Restricted_Site_Access {
 			return $original_value;
 		}
 
-		$protocol = ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ? 'https' : 'http' );
-		$request  = isset( $_SERVER['HTTP_HOST'] ) && sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) )
-		. isset( $_SERVER['REQUEST_URI'] ) && sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$protocol = ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ) ? 'https' : 'http';
+		$host     = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+		$path     = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 		// We need to determine current URL via php because $wp->request is not set at this point.
-		$current_request = esc_url_raw( "$protocol://$request" );
+		$current_request = esc_url_raw( "{$protocol}://{$host}{$path}" );
+		// Strip the query string.
+		$current_request = explode( '?', $current_request, 2 )[0];
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! get_option( 'permalink_structure' ) && isset( $_GET['rest_route'] ) ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -137,6 +137,9 @@ class Restricted_Site_Access {
 	 * @return bool
 	 */
 	public static function is_api_request( $original_value ) {
+		if ( did_action( 'init' ) ) {
+			return $original_value;
+		}
 
 		$protocol = ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ? 'https' : 'http' );
 		$request  = isset( $_SERVER['HTTP_HOST'] ) && sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) )

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -126,7 +126,12 @@ class Restricted_Site_Access {
 	}
 
 	/**
-	 * Add filter to override application_password_is_api_request filter. This has to be done since rest API isn't been loaded until we call restrict_access.
+	 * Determine if this is a REST request.
+	 * 
+	 * Determine whether this is a REST API request based on the URL. As RSA redirects prior
+	 * to the `init` hook running, RSA needs to replace the API check in wp_authenticate_application_password().
+	 *
+	 * @since x.x.x
 	 *
 	 * @param bool $original_value Original value passed by filter.
 	 * @return bool

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -122,6 +122,27 @@ class Restricted_Site_Access {
 
 		add_filter( 'pre_option_blog_public', array( __CLASS__, 'pre_option_blog_public' ), 10, 1 );
 		add_filter( 'pre_site_option_blog_public', array( __CLASS__, 'pre_option_blog_public' ), 10, 1 );
+		add_filter( 'application_password_is_api_request', array( __CLASS__, 'is_api_request') );
+	}
+
+	/**
+	 * Add filter to override application_password_is_api_request filter. This has to be done since rest API isn't been loaded until we call restrict_access
+	 *
+	 * @param bool $original_value Original value passed by filter
+	 * @return bool
+	 */
+	public static function is_api_request( $original_value ) {
+
+		// We need to determine current URL via php because $wp->request is not set at this point
+		$current_request = ( isset($_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? "https" : "http" ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+
+		if ( ! get_option( 'permalink_structure' ) && isset( $_GET['rest_route'] ) ) {
+			return true;
+		} elseif ( strpos( $current_request, home_url( '/wp-json' ) ) === 0 ) {
+			return true;
+		}
+
+		return $original_value;
 	}
 
 	/**

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -122,20 +122,25 @@ class Restricted_Site_Access {
 
 		add_filter( 'pre_option_blog_public', array( __CLASS__, 'pre_option_blog_public' ), 10, 1 );
 		add_filter( 'pre_site_option_blog_public', array( __CLASS__, 'pre_option_blog_public' ), 10, 1 );
-		add_filter( 'application_password_is_api_request', array( __CLASS__, 'is_api_request') );
+		add_filter( 'application_password_is_api_request', array( __CLASS__, 'is_api_request' ) );
 	}
 
 	/**
-	 * Add filter to override application_password_is_api_request filter. This has to be done since rest API isn't been loaded until we call restrict_access
+	 * Add filter to override application_password_is_api_request filter. This has to be done since rest API isn't been loaded until we call restrict_access.
 	 *
-	 * @param bool $original_value Original value passed by filter
+	 * @param bool $original_value Original value passed by filter.
 	 * @return bool
 	 */
 	public static function is_api_request( $original_value ) {
 
-		// We need to determine current URL via php because $wp->request is not set at this point
-		$current_request = ( isset($_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? "https" : "http" ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+		$protocol = ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ? 'https' : 'http' );
+		$request  = isset( $_SERVER['HTTP_HOST'] ) && sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) )
+		. isset( $_SERVER['REQUEST_URI'] ) && sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 
+		// We need to determine current URL via php because $wp->request is not set at this point.
+		$current_request = esc_url_raw( "$protocol://$request" );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! get_option( 'permalink_structure' ) && isset( $_GET['rest_route'] ) ) {
 			return true;
 		} elseif ( strpos( $current_request, home_url( '/wp-json' ) ) === 0 ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -151,7 +151,10 @@ class Restricted_Site_Access {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! get_option( 'permalink_structure' ) && isset( $_GET['rest_route'] ) ) {
 			return true;
-		} elseif ( strpos( $current_request, home_url( '/wp-json' ) ) === 0 ) {
+		} elseif (
+			strpos( $current_request, home_url( '/wp-json/' ) ) === 0
+			|| home_url( '/wp-json' ) === $current_request
+		) {
 			return true;
 		}
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -127,7 +127,7 @@ class Restricted_Site_Access {
 
 	/**
 	 * Determine if this is a REST request.
-	 * 
+	 *
 	 * Determine whether this is a REST API request based on the URL. As RSA redirects prior
 	 * to the `init` hook running, RSA needs to replace the API check in wp_authenticate_application_password().
 	 *


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description. The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds support of WordPress Application password to this plugin.

Closes #237

### How to test the Change

Since this issue has steamed from https://github.com/10up/distributor/issues/986, let's try to see a usecase using it.

1. Create two sites - `source.test` and `destination.test` . Install `distributor` plugin in both of them and RSA in `source.test`. 
2. Checkout this branch in RSA plugin and activate it.
3. Create Application Password in `source.test`
4. Add the `source.test` distributor connection in `destination.test`. Note: You may need to add it manually and add Application password created in step 3.
5. Note that you'll be able to add connection(you can't do that without this PR). 
6. Clone posts from distributor.

### Changelog Entry
> Added - WordPress application password support


### Credits
Props @kirtangajjar

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests pass.
