### PR TITLE
Changes the 2 incorrect placeholders.

### DIFF
--- a/wp-cli.php
+++ b/wp-cli.php
@@ -215,7 +215,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			case 'redirect':
 				$success_msg = sprintf(
 					/* translators: %s: Context: "Site" or "Network". %s: Redirect URL. */
-					__( '%%s redirecting visitors to "%s"', 'restricted-site-access' ),
+					__( '%s redirecting visitors to "%s"', 'restricted-site-access' ),
 					$updated_options['redirect_url']
 				);
 				break;
@@ -226,7 +226,7 @@ class Restricted_Site_Access_CLI extends WP_CLI_Command {
 			case 'page':
 				$success_msg = sprintf(
 					/* translators: %s: "Site" or "Network". %s: Page title. */
-					__( '%%s showing visitors page "%s"', 'restricted-site-access' ),
+					__( '%s showing visitors page "%s"', 'restricted-site-access' ),
 					get_the_title( $page )
 				);
 				break;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Replaces 2 instances of incorrect placeholder `%%s` with the correct one: `%s`.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #259

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Replaces 2 instances of incorrect placeholder `%%s` with the correct one: `%s` in `wp-cli.php`.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @tobifjellner @kebbet

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
