### PR TITLE
Upgrade Cypress to version 13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "cypress-mochawesome-reporter": "^3.4.0"
       },
       "devDependencies": {
-        "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
+        "@10up/cypress-wp-utils": "^0.2.0",
         "@wordpress/dependency-extraction-webpack-plugin": "^4.0.0",
-        "@wordpress/env": "^5.4.0",
+        "@wordpress/env": "^8.7.0",
         "@wordpress/eslint-plugin": "^10.0.2",
         "@wordpress/scripts": "^23.4.0",
-        "cypress": "^10.3.0",
+        "cypress": "^13.2.0",
         "cypress-file-upload": "^5.0.8",
         "eslint": "^8.8.0",
         "prettier": "^2.8.7",
@@ -25,11 +25,10 @@
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/10up/cypress-wp-utils.git#cd1db18bd6f86a1002a8105d654781ac325040db",
-      "integrity": "sha512-yT3q4MxZyIxWFbpuRNOBj3+gnnwTUzZ2fCKjC0fgEijCPD0rLZK/XGsxEgPJ++eKEbsWBxA4+p+4J4lbyUMQgw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
@@ -1902,9 +1901,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1919,7 +1918,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -3566,10 +3565,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
-      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
-      "devOptional": true
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -4410,9 +4408,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.5.0.tgz",
-      "integrity": "sha512-Dm/XHkCD8rVSfm9fGvK92EbfZ7UhZCkIoNdv8wq21cwiZ0/2O0iPaC73aJ/4pTaY0PBODz5Z/LD4gE/cRSDcxg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
+      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -5458,9 +5456,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axe-core": {
       "version": "4.5.0",
@@ -6615,6 +6613,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7259,14 +7258,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -7278,10 +7277,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -7296,12 +7295,13 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -7311,7 +7311,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-file-upload": {
@@ -7358,11 +7358,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
     },
     "node_modules/cypress/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -7419,6 +7414,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/cypress/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/cypress/node_modules/extract-zip": {
       "version": "2.0.1",
@@ -14595,9 +14598,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -17111,6 +17114,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -21166,10 +21177,10 @@
   },
   "dependencies": {
     "@10up/cypress-wp-utils": {
-      "version": "git+ssh://git@github.com/10up/cypress-wp-utils.git#cd1db18bd6f86a1002a8105d654781ac325040db",
-      "integrity": "sha512-yT3q4MxZyIxWFbpuRNOBj3+gnnwTUzZ2fCKjC0fgEijCPD0rLZK/XGsxEgPJ++eKEbsWBxA4+p+4J4lbyUMQgw==",
-      "dev": true,
-      "from": "@10up/cypress-wp-utils@github:10up/cypress-wp-utils#build"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
+      "dev": true
     },
     "@ampproject/remapping": {
       "version": "2.2.0",
@@ -22456,9 +22467,9 @@
       "requires": {}
     },
     "@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -22473,7 +22484,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -23720,10 +23731,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
-      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
-      "devOptional": true
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -24400,9 +24410,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.5.0.tgz",
-      "integrity": "sha512-Dm/XHkCD8rVSfm9fGvK92EbfZ7UhZCkIoNdv8wq21cwiZ0/2O0iPaC73aJ/4pTaY0PBODz5Z/LD4gE/cRSDcxg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
+      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -25132,9 +25142,9 @@
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "axe-core": {
       "version": "4.5.0",
@@ -26005,7 +26015,8 @@
     "commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true
     },
     "comment-parser": {
       "version": "1.3.0",
@@ -26493,13 +26504,13 @@
       }
     },
     "cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "requires": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -26511,10 +26522,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -26529,23 +26540,19 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.18.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-          "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -26585,6 +26592,11 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
         },
         "extract-zip": {
           "version": "2.0.1",
@@ -31979,9 +31991,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -33783,6 +33795,11 @@
           "dev": true
         }
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "role": "developer"
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
+    "@10up/cypress-wp-utils": "^0.2.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^4.0.0",
-    "@wordpress/env": "^5.4.0",
+    "@wordpress/env": "^8.7.0",
     "@wordpress/eslint-plugin": "^10.0.2",
     "@wordpress/scripts": "^23.4.0",
-    "cypress": "^10.3.0",
+    "cypress": "^13.2.0",
     "cypress-file-upload": "^5.0.8",
     "eslint": "^8.8.0",
     "prettier": "^2.8.7",

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
+wp-env run tests-wordpress chmod -c ugo+w /var/www/html
 
-npm run env run tests-cli "wp core multisite-convert --title='RSA Multisite'"
-npm run env run tests-cli "wp post create --post_type=page --post_title='One' --post_status='publish'"
-npm run env run tests-cli "wp post create --post_type=page --post_title='Two' --post_status='publish'"
-npm run env run tests-cli "wp plugin activate rsa-seeder --network"
-npm run env run tests-cli wp rewrite structure '/%postname%/' --hard
+wp-env run tests-cli wp core multisite-convert --title='RSA Multisite'
+wp-env run tests-cli wp post create --post_type=page --post_title='One' --post_status='publish'
+wp-env run tests-cli wp post create --post_type=page --post_title='Two' --post_status='publish'
+wp-env run tests-cli wp plugin activate rsa-seeder --network
+wp-env run tests-cli wp rewrite structure '/%postname%/' --hard

--- a/tests/cypress/config.js
+++ b/tests/cypress/config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
-const { readConfig }   = require('@wordpress/env/lib/config');
+const { loadConfig } = require('@wordpress/env/lib/config');
+const getCacheDirectory = require('@wordpress/env/lib/config/get-cache-directory');
 
 module.exports = defineConfig({
   fixturesFolder: 'tests/cypress/fixtures',
@@ -41,14 +42,15 @@ module.exports = defineConfig({
  * @returns config Updated Cypress Config object.
  */
 const setBaseUrl = async (on, config) => {
-  const wpEnvConfig = await readConfig('wp-env');
+  const cacheDirectory = await getCacheDirectory();
+  const wpEnvConfig = await loadConfig(cacheDirectory);
 
   if (wpEnvConfig) {
     const port = wpEnvConfig.env.tests.port || null;
 
     if (port) {
-      config.baseUrl = `http://${wpEnvConfig.env.tests.config.WP_TESTS_DOMAIN}:${port}`;
-    }
+	  config.baseUrl = wpEnvConfig.env.tests.config.WP_SITEURL;
+	}
   }
 
   return config;

--- a/tests/cypress/e2e/activation-deactivation.test.js
+++ b/tests/cypress/e2e/activation-deactivation.test.js
@@ -3,6 +3,9 @@ describe( 'Activation/Deactivation', () => {
 		cy.request( {
 			url: '/wp-json/rsa/v1/seed/activation-deactivation'
 		} );
+	} );
+
+	beforeEach( () => {
 		cy.login();
 	} );
 

--- a/tests/cypress/e2e/add-invalid-addresses.test.js
+++ b/tests/cypress/e2e/add-invalid-addresses.test.js
@@ -3,7 +3,9 @@ describe( 'Add invalid IPv4, IPv6 addresses', () => {
 		cy.request( {
 			url: '/wp-json/rsa/v1/seed/add-invalid-addresses'
 		} );
-		cy.login();
+	} );
+
+	beforeEach( () => {
 		cy.visitAdminPage( 'network/settings.php' );
 	} );
 
@@ -13,31 +15,26 @@ describe( 'Add invalid IPv4, IPv6 addresses', () => {
 	} );
 
 	it( 'Test error for invalid IPv4 subnet', () => {
-		cy.reload();
 		cy.addIp( '172.10.23.4/33', 'Invalid IPv4 subnet' );
 		cy.get( '#rsa-error-container' ).contains( 'The IP entered is invalid.' );
 	} );
 
 	it( 'Test error for invalid IPv4 pattern', () => {
-		cy.reload();
 		cy.addIp( '10.256.*', 'Invalid IPv4 pattern' );
 		cy.get( '#rsa-error-container' ).contains( 'The IP entered is invalid.' );
 	} );
 
 	it( 'Test error for invalid IPv6 single address', () => {
-		cy.reload();
 		cy.addIp( '2001:db8:3333:4444:5555:6666:7777:888g', 'Invalid IPv6 single address' );
 		cy.get( '#rsa-error-container' ).contains( 'The IP entered is invalid.' );
 	} );
 
 	it( 'Test error for invalid IPv6 subnet', () => {
-		cy.reload();
 		cy.addIp( '2001:0db8:3333:4444:0000:0000:0000:0000/129', 'Invalid IPv6 subnet' );
 		cy.get( '#rsa-error-container' ).contains( 'The IP entered is invalid.' );
 	} );
 
 	it( 'Test error for invalid IPv6 pattern', () => {
-		cy.reload();
 		cy.addIp( '2001:0db8:3333:4444:0000:0000:0000:::', 'Invalid IPv6 subnet' );
 		cy.get( '#rsa-error-container' ).contains( 'The IP entered is invalid.' );
 	} );

--- a/tests/cypress/e2e/add-valid-addresses.test.js
+++ b/tests/cypress/e2e/add-valid-addresses.test.js
@@ -3,7 +3,9 @@ describe( 'Add & save valid IPv4, IPv6 addresses', () => {
 		cy.request( {
 			url: '/wp-json/rsa/v1/seed/add-valid-addresses'
 		} )
-		cy.login();
+	} );
+
+	beforeEach( () => {
 		cy.visitAdminPage( 'network/settings.php' );
 	} );
 
@@ -29,16 +31,16 @@ describe( 'Add & save valid IPv4, IPv6 addresses', () => {
 
 	it( 'Add IPv6 pattern', () => {
 		cy.addIp( '2001:db8:3333:4444:5555:6666:*:*', 'IPv6 pattern' );
-		cy.wait(300);
 	} );
 
-	after( () => {
+	afterEach( () => {
 		cy.saveSettings();
 	} )
 } );
 
 describe( 'Validate save operation', () => {
 	it( 'Validate each saved IP addresses', () => {
+		cy.visitAdminPage( 'network/settings.php' );
 		cy.get( '#ip_list .rsa_unrestricted_ip_row' ).eq( 0 ).find( 'input' ).eq( 0 ).should( 'have.value', '172.10.23.4' );
 		cy.get( '#ip_list .rsa_unrestricted_ip_row' ).eq( 0 ).find( 'input' ).eq( 1 ).should( 'have.value', 'IPv4 single address' );
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -23,20 +23,6 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-Cypress.Commands.add(
-	'login',
-	( username = 'admin', password = 'password' ) => {
-		cy.visit( `/wp-admin` );
-		cy.get( 'body' ).then( ( $body ) => {
-			if ( $body.find( '#wpwrap' ).length == 0 ) {
-				cy.get( 'input#user_login' ).clear();
-				cy.get( 'input#user_login' ).click().type( username );
-				cy.get( 'input#user_pass' ).type( `${ password }{enter}` );
-			}
-		} );
-	}
-);
-
 Cypress.Commands.add( 'visitAdminPage', ( page = 'index.php' ) => {
 	cy.login();
 	if ( page.includes( 'http' ) ) {

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -37,9 +37,3 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   return true
 })
 
-// Preserve WP cookies.
-beforeEach(() => {
-  Cypress.Cookies.defaults({
-    preserve: /^wordpress.*?/,
-  });
-});


### PR DESCRIPTION
### Description of the Change
This PR upgrades the Cypress, Cypress utils lib, and @wordpress/env. Updates needed files as part of the upgrade.

- Bump Cypress version from 10.3.0 to 13.2.0
- Bump @10up/cypress-wp-utils version to 0.2.0
- Bump @wordpress/env version from 5.4.0 to 8.7.0

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #272

### How to test the Change
Make sure PR `PASS` E2E tests check OR verify E2E tests locally.

### Changelog Entry
> Changed - Bump `Cypress` version from 10.3.0 to 13.2.0
> Changed - Bump `@10up/cypress-wp-utils` version to 0.2.0
> Changed - Bump `@wordpress/env` version from 5.4.0 to 8.7.0


### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
