### PR TITLE
chore: fix autovivification on false

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -314,12 +314,10 @@ class Restricted_Site_Access {
 	 * @param boolean $network Whether this is a network install. Default false.
 	 */
 	public static function get_options( $network = false ) {
-		$options = array();
-
 		if ( $network ) {
-			$options = get_site_option( 'rsa_options' );
+			$options = get_site_option( 'rsa_options', array() );
 		} else {
-			$options = get_option( 'rsa_options' );
+			$options = get_option( 'rsa_options', array() );
 		}
 
 		// Fill in defaults where values aren't set.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Fixes the [autovivification issue](https://wiki.php.net/rfc/autovivification_false) referenced in the issue.

Although it currently only throws a warning when running PHP 8.1 and won't throw a fatal error until PHP 9.0, this could build up in logs.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #280

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Install plugin on fresh WP install running on PHP 8.1
2. Check user FE.
3. Check logs (or Query Monitor) for deprecated notice `PHP Deprecated:  Automatic conversion of false to array is deprecated`.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Fixed - Prep for [PHP 8.1 deprecated autovivification on false](https://wiki.php.net/rfc/autovivification_false).

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @mae829 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
