### PR TITLE
PHP 8.1 Compat

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -321,6 +321,7 @@ class Restricted_Site_Access {
 		} else {
 			$options = get_option( 'rsa_options' );
 		}
+		$options = is_array( $options ) ? $options : [];
 
 		// Fill in defaults where values aren't set.
 		foreach ( self::$fields as $field_name => $field_details ) {

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -321,7 +321,8 @@ class Restricted_Site_Access {
 		} else {
 			$options = get_option( 'rsa_options' );
 		}
-		$options = is_array( $options ) ? $options : [];
+
+		$options = is_array( $options ) ? $options : array();
 
 		// Fill in defaults where values aren't set.
 		foreach ( self::$fields as $field_name => $field_details ) {


### PR DESCRIPTION
Tested in PHP 8.1:
"PHP message: PHP Deprecated:  Automatic conversion of false to array is deprecated in /var/www/wp-content/plugins/restricted-site-access/restricted_site_access.php on line 319"

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Simple change to make sure $options var is array and not produce warning in PHP 8.1+
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
Test in PHP 8.1+ and simply check the error log
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed: PHP 8.1 compat for get_options()

<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits

@turtlepod 

<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
