### PR TITLE
Ensure the default state for new installs is more secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Visitors that are not logged in or allowed by IP address will not be able to bro
 
 Restricted Site Access is not meant to be a top secret data safe, but simply a reliable and convenient way to handle unwanted visitors.
 
-In 7.3.2, two new filters have been added that can be utilized to help prevent IP spoofing attacks. The first filter allows you to set up a list of approved proxy IP addresses and the second allows you to set up a list of approved HTTP headers. By default, these filters will not change existing behavior. It is recommended to review these filters and utilize them appropriately for your site to secure things further.
+In 7.3.2, two new filters have been added that can be utilized to help prevent IP spoofing attacks. The first filter allows you to set up a list of approved proxy IP addresses and the second allows you to set up a list of approved HTTP headers. For any sites that were using Restricted Site Access prior to version 7.5.0, a handful of HTTP headers are trusted by default. It is recommended to review these filters and utilize them appropriately for your site to secure things further.
 
 If your site is not running behind a proxy, we recommend doing the following:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "cypress": "^13.2.0",
         "cypress-file-upload": "^5.0.8",
         "eslint": "^8.8.0",
+        "mochawesome-json-to-md": "^0.7.2",
         "prettier": "^2.8.7"
       }
     },
@@ -15646,6 +15647,19 @@
       },
       "peerDependencies": {
         "mocha": ">=7"
+      }
+    },
+    "node_modules/mochawesome-json-to-md": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+      "integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+      "deprecated": "🙌 Thanks for using it. We recommend upgrading to the newer version, 1.x.x. Check out https://www.npmjs.com/package/mochawesome-json-to-md for details.",
+      "dev": true,
+      "dependencies": {
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "mochawesome-json-to-md": "index.js"
       }
     },
     "node_modules/mochawesome-merge": {
@@ -33796,6 +33810,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "mochawesome-json-to-md": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+      "integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+      "dev": true,
+      "requires": {
+        "yargs": "^17.0.1"
       }
     },
     "mochawesome-merge": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cypress": "^13.2.0",
     "cypress-file-upload": "^5.0.8",
     "eslint": "^8.8.0",
+    "mochawesome-json-to-md": "^0.7.2",
     "prettier": "^2.8.7"
   },
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ Visitors that are not logged in or allowed by IP address will not be able to bro
 
 Restricted Site Access is not meant to be a top secret data safe, but simply a reliable and convenient way to handle unwanted visitors.
 
-In 7.3.2, two new filters have been added that can be utilized to help prevent IP spoofing attacks. The first filter allows you to set up a list of approved proxy IP addresses and the second allows you to set up a list of approved HTTP headers. By default, these filters will not change existing behavior. It is recommended to review these filters and utilize them appropriately for your site to secure things further.
+In 7.3.2, two new filters have been added that can be utilized to help prevent IP spoofing attacks. The first filter allows you to set up a list of approved proxy IP addresses and the second allows you to set up a list of approved HTTP headers. For any sites that were using Restricted Site Access prior to version 7.5.0, a handful of HTTP headers are trusted by default. It is recommended to review these filters and utilize them appropriately for your site to secure things further.
 
 If your site is not running behind a proxy, we recommend doing the following:
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1575,6 +1575,26 @@ class Restricted_Site_Access {
 	 * @param boolean $network_active Whether the plugin network active.
 	 */
 	public static function activation( $network_active ) {
+		// For new or non-configured installs, store the RSA version.
+		// This is used later to determine what default HTTP headers we trust.
+		if ( $network_active ) {
+			$sites = get_sites();
+
+			foreach ( $sites as $site ) {
+				switch_to_blog( $site->blog_id );
+
+				if ( ! get_option( 'rsa_activation_version', false ) && ! get_option( 'rsa_options', false ) ) {
+					update_option( 'rsa_activation_version', RSA_VERSION );
+				}
+
+				restore_current_blog();
+			}
+		} else {
+			if ( ! get_option( 'rsa_activation_version', false ) && ! get_option( 'rsa_options', false ) ) {
+				update_option( 'rsa_activation_version', RSA_VERSION );
+			}
+		}
+
 		if ( ! $network_active ) {
 			update_option( 'blog_public', 2 );
 		}
@@ -1735,16 +1755,22 @@ class Restricted_Site_Access {
 	 * @return string
 	 */
 	public static function get_ip_from_headers() {
-		$ip                  = '';
-		$old_trusted_headers = array(
-			'HTTP_CF_CONNECTING_IP',
-			'HTTP_CLIENT_IP',
-			'HTTP_X_FORWARDED_FOR',
-			'HTTP_X_FORWARDED',
-			'HTTP_X_CLUSTER_CLIENT_IP',
-			'HTTP_FORWARDED_FOR',
-			'HTTP_FORWARDED',
-		);
+		$ip = '';
+
+		// For any active version prior to 7.5.0, we use the default trusted headers.
+		if ( version_compare( get_option( 'rsa_activation_version', '0.0.0' ), '7.5.0', '<' ) ) {
+			$trusted_headers = array(
+				'HTTP_CF_CONNECTING_IP',
+				'HTTP_CLIENT_IP',
+				'HTTP_X_FORWARDED_FOR',
+				'HTTP_X_FORWARDED',
+				'HTTP_X_CLUSTER_CLIENT_IP',
+				'HTTP_FORWARDED_FOR',
+				'HTTP_FORWARDED',
+			);
+		} else {
+			$trusted_headers = array();
+		}
 
 		/**
 		 * Filter hook to set array of trusted IP address headers.
@@ -1763,9 +1789,9 @@ class Restricted_Site_Access {
 		 * trust so these headers will only be used if a request came from
 		 * the proxy.
 		 *
-		 * @param string[] $trusted_proxies Array of trusted IP Address headers.
+		 * @param string[] $trusted_headers Array of trusted IP Address headers.
 		 */
-		$trusted_headers = apply_filters( 'rsa_trusted_headers', array() );
+		$trusted_headers = apply_filters( 'rsa_trusted_headers', $trusted_headers );
 
 		// Add the REMOTE_ADDR value to the end of the array.
 		$trusted_headers[] = 'REMOTE_ADDR';
@@ -2115,6 +2141,7 @@ function restricted_site_access_uninstall() {
 				update_option( 'blog_public', 1 );
 			}
 			delete_option( 'rsa_options' );
+			delete_option( 'rsa_activation_version' );
 
 			restore_current_blog();
 		}
@@ -2123,6 +2150,7 @@ function restricted_site_access_uninstall() {
 			update_option( 'blog_public', 1 );
 		}
 		delete_option( 'rsa_options' );
+		delete_option( 'rsa_activation_version' );
 	}
 }
 

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1735,8 +1735,8 @@ class Restricted_Site_Access {
 	 * @return string
 	 */
 	public static function get_ip_from_headers() {
-		$ip              = '';
-		$trusted_headers = array(
+		$ip                  = '';
+		$old_trusted_headers = array(
 			'HTTP_CF_CONNECTING_IP',
 			'HTTP_CLIENT_IP',
 			'HTTP_X_FORWARDED_FOR',
@@ -1749,30 +1749,23 @@ class Restricted_Site_Access {
 		/**
 		 * Filter hook to set array of trusted IP address headers.
 		 *
-		 * Most CDN providers will set the IP address of the client in a number
-		 * of headers. This allows the plugin to detect the IP address of the client
-		 * even if it is behind a proxy.
+		 * By default we only trust the REMOTE_ADDR header, as other
+		 * headers can easily be spoofed.
 		 *
-		 * Use this hook to modify the permitted proxy headers. For sites without a
-		 * CDN (or local proxy) it is recommended to add a filter to this hook to
-		 * return an empty array.
+		 * If your site is behind a proxy, typically the REMOTE_ADDR header
+		 * will contain the IP address of the proxy and not the client. To
+		 * deal with this situation, you'll need to use this filter
+		 * to set any other headers you want to trust.
 		 *
-		 * add_filter( 'rsa_trusted_headers', '__return_empty_array' );
-		 *
-		 * By default, the following headers are trusted:
-		 * - HTTP_CF_CONNECTING_IP
-		 * - HTTP_CLIENT_IP
-		 * - HTTP_X_FORWARDED_FOR
-		 * - HTTP_X_FORWARDED
-		 * - HTTP_X_CLUSTER_CLIENT_IP
-		 * - HTTP_FORWARDED_FOR
-		 * - HTTP_FORWARDED
-		 *
-		 * To allow for CDNs, these headers take priority over the REMOTE_ADDR value.
+		 * Note that by doing this you will open your site up to IP spoofing
+		 * attacks so proceed with caution. If possible, you should also use
+		 * the rsa_trusted_proxies filter to set the proxy IP addresses you
+		 * trust so these headers will only be used if a request came from
+		 * the proxy.
 		 *
 		 * @param string[] $trusted_proxies Array of trusted IP Address headers.
 		 */
-		$trusted_headers = apply_filters( 'rsa_trusted_headers', $trusted_headers );
+		$trusted_headers = apply_filters( 'rsa_trusted_headers', array() );
 
 		// Add the REMOTE_ADDR value to the end of the array.
 		$trusted_headers[] = 'REMOTE_ADDR';


### PR DESCRIPTION
### Description of the Change

In #198 we introduced some new filters that can be used to make RSA more secure. These filters do two things:

1. Allow you to set which HTTP headers to trust
2. Allow you to set which proxy IP addresses to trust

The idea being that if you want to trust any HTTP headers besides `REMOTE_ADDR`, more than likely you're doing this because your site is behind a proxy. In this situation, you should only trust those additional headers if the request is coming from your proxy IP address, which can be set with that second filter.

But all of this is disabled by default and has to be enabled through the use of these filters. This means for sites that use IP restriction, there is a chance of an IP spoofing attack being used.

As such, we've decided to make the core behavior more secure and allow individual sites to opt-in to additional HTTP headers using the filter, instead of the opposite approach we have now.

That said, we also want to maintain backwards compatibility so for any sites that are currently configured to use RSA, they will continue to use the existing list of HTTP headers. They can use the filter to change that list (and are recommended to do so), for instance removing those headers entirely by doing:

`add_filter( 'rsa_trusted_headers', '__return_empty_array' );`

But any new installs or newly configured installs will have to use that filter to set additional headers as needed. And as mentioned above, if trusting any additional headers, ideally you should be using the `rsa_trusted_proxies` filter to set a list of trusted proxy IP addresses, so the additional headers will only be used if one of those IP addresses matches.

Closes #195 

### How to test the Change

1. WIth the latest released version of RSA, configure it to restrict access based on IP addresses
2. Enter at least one IP address that is allowed but ensure this isn't your IP address
3. Try to access the site (without being logged in) and notice access is restricted
4. In your HTTP request client of choice (Postman or direct curl requests for instance) make a request to your site but make sure you set one of the default HTTP headers to match your IP address. For instance: `curl --location --request POST 'https://rsa.test' --header 'CF-Connecting-Ip: 127.0.0.2'`
5. Note you should gain access to the site even though your actual IP address isn't allowed
6. Now checkout the changes in this PR
7. To simulate a new instance, set the option `rsa_activation_version` to 7.5.0 on whatever site you're testing on
8. Run through the steps above again and notice you'll no longer be able to access the site in either scenario
9. Add the following code, replacing the HTTP header name with whatever header you're testing
```php
add_filter(
	'rsa_trusted_headers',
	function( $trusted_headers ) {
		return array_merge( array( 'HTTP_CF_CONNECTING_IP' ), $trusted_headers );
	}
);
```
10. Run through the steps again and notice you should have access now when spoofing
11. Remove the `rsa_activation_version` option and and the code added above and run through the steps again. This simulates an existing install. Note you should be able to access the site when spoofing
12. Add the following code:
```php
add_filter(
	'rsa_trusted_headers',
	'__return_empty_array'
);
```
13. Note you should no longer have access when spoofing

### Changelog Entry

> Security - For new installs, ensure we only trust the `REMOTE_ADDR` HTTP header by default. Existing installs will still utilize the old list of approved headers but can modify this (and are recommended to) by using the `rsa_trusted_headers` filter

### Credits

Props @dkotter, @peterwilsoncc, @dustinrue, @mikhail-net

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
