### PR TITLE
Add support for the WordPress.org plugin preview

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -1,14 +1,24 @@
 name: Plugin asset/readme update
+
 on:
   push:
     branches:
     - trunk
+
 jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        npm install
+        npm run build
+        composer i --no-dev
+
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "\/wp-admin\/options-reading.php",
+	"preferredVersions": {
+		"php": "7.4",
+		"wp": "latest"
+	},
+	"phpExtensionBundles": ["kitchen-sink"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org\/plugins",
+				"slug": "restricted-site-access"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "rsa_options": {
+          "approach": 3,
+          "allowed": [
+            "127.0.0.1"
+          ],
+          "comment": [
+            "Example of an allowed IP address"
+          ]
+        },
+        "rsa_activation_version": "7.5.0"
+      }
+    }
+	]
+}

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -22,20 +22,20 @@
 				"activate": true
 			}
 		},
-    {
-      "step": "setSiteOptions",
-      "options": {
-        "rsa_options": {
-          "approach": 3,
-          "allowed": [
-            "127.0.0.1"
-          ],
-          "comment": [
-            "Example of an allowed IP address"
-          ]
-        },
-        "rsa_activation_version": "7.5.0"
-      }
-    }
+		{
+			"step": "setSiteOptions",
+			"options": {
+				"rsa_options": {
+					"approach": 3,
+					"allowed": [
+						"127.0.0.1"
+					],
+					"comment": [
+						"Example of an allowed IP address"
+					]
+				},
+				"rsa_activation_version": "7.5.0"
+			}
+		}
 	]
 }


### PR DESCRIPTION
### Description of the Change

WordPress.org recently launched support for plugin previews utilizing the WordPress Playground feature. Plugins wanting to take advantage of this need to opt in by setting up a `blueprint.json` file that configures how the preview should load. This PR adds in that file that does the following:

1. Sets up an environment running PHP 7.4 (our supported minimum) and the latest version of WordPress
2. Logs into the admin
3. Installs and activates the plugin
4. Sets up some default options
5. Sends users to the Reading settings page

In order to actually test the restriction, you'll have to log out and then on the login screen, click on the `Go to my WordPress website`. At this point you should see the restriction message.

Note that this PR is targeted to `trunk` so we can take advantage of our Plugin Asset Update Action to deploy these changes without having to push out a new release. This won't work though until https://github.com/10up/action-wordpress-plugin-asset-update/pull/54 is released.

Also note once these changes are on .org, the preview button will need to be enabled in a test state. Once verified as working, we can enable it for all users.

### How to test the Change

The WordPress Playground allows you to spin up a new environment directly through the URL, by going to `https://playground.wordpress.net/#` and pasting your JSON config after the `#`. In this case, the URL should be: https://playground.wordpress.net/#{%20%22$schema%22:%20%22https://playground.wordpress.net/blueprint-schema.json%22,%20%22landingPage%22:%20%22\/wp-admin\/options-reading.php%22,%20%22preferredVersions%22:%20{%20%22php%22:%20%227.4%22,%20%22wp%22:%20%22latest%22%20},%20%22phpExtensionBundles%22:%20[%22kitchen-sink%22],%20%22steps%22:%20[%20{%20%22step%22:%20%22login%22,%20%22username%22:%20%22admin%22,%20%22password%22:%20%22password%22%20},%20{%20%22step%22:%20%22installPlugin%22,%20%22pluginZipFile%22:%20{%20%22resource%22:%20%22wordpress.org\/plugins%22,%20%22slug%22:%20%22restricted-site-access%22%20},%20%22options%22:%20{%20%22activate%22:%20true%20}%20},%20{%20%22step%22:%20%22setSiteOptions%22,%20%22options%22:%20{%20%22rsa_options%22:%20{%20%22approach%22:%203,%20%22allowed%22:%20[%20%22127.0.0.1%22%20],%20%22comment%22:%20[%20%22Example%20of%20an%20allowed%20IP%20address%22%20]%20},%20%22rsa_activation_version%22:%20%227.5.0%22%20}%20}%20]%20}

### Changelog Entry

> Added - Support for the WordPress.org plugin preview

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
