### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -48,7 +48,7 @@ jobs:
         core:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.3'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -4,25 +4,6 @@
 
 [![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![E2E Tests](https://github.com/10up/restricted-site-access/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/restricted-site-access/actions/workflows/cypress.yml) [![PHPUnit](https://github.com/10up/restricted-site-access/actions/workflows/phpunit.yml/badge.svg)](https://github.com/10up/restricted-site-access/actions/workflows/phpunit.yml) [![Release Version](https://img.shields.io/github/release/10up/restricted-site-access.svg)](https://github.com/10up/restricted-site-access/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/restricted-site-access?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/restricted-site-access.svg)](https://github.com/10up/restricted-site-access/blob/develop/LICENSE.md)
 
-## Table of Contents
-* [Features](#features)
-* [Installation](#installation)
-* [FAQs](#frequently-asked-questions)
-  * [Where do I change the restriction settings?](#where-do-i-change-the-restriction-settings)
-  * [It’s not working! My site is wide open!](#its-not-working-my-site-is-wide-open)
-  * [How do I allow access to specific parts of my site?](#how-do-i-allow-access-to-specific-pages-or-parts-of-my-site)
-  * [How secure is this plug-in?](#how-secure-is-this-plug-in)
-  * [Why can't logged-in multisite users see all my sites?](#why-cant-logged-in-users-see-all-the-sites-on-my-multisite-instance)
-  * [Is there a way to configure this with WP-CLI?](#is-there-a-way-to-configure-this-with-wp-cli)
-  * [How can I programmatically define whitelisted IPs?](#how-can-i-programmatically-define-whitelisted-ips)
-  * [Is there a constant to control my site restriction?](#is-there-a-constant-i-can-set-to-ensure-my-site-is-or-is-not-restricted)
-  * [Can I provide access to my site based on custom HTTP headers?](#can-i-provide-access-to-my-site-based-on-custom-http-headers)
-  * [What does 'Discourage search engines from indexing this site' do?](#what-does-discourage-search-engines-from-indexing-this-site-do)
-  * [What does 'Restrict site access to visitors who are logged in or allowed by IP address' do?](#what-does-restrict-site-access-to-visitors-who-are-logged-in-or-allowed-by-ip-address-do)
-* [Support](#support-level)
-* [Changelog](#changelog)
-* [Contributing](#contributing)
-
 ## Features
 
 Limit access your site to visitors who are logged in or accessing the site from a set of specified IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. A great solution for Extranets, publicly hosted Intranets, or parallel development / staging sites.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, jakemgold, rcbth, thinkoomph, tlovett1, jeffpaul, nomnom99
 Donate link:       https://10up.com/plugins/restricted-site-access-wordpress/
 Tags:              privacy, restricted, restrict, privacy, limited, permissions, security, block
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        7.5.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://10up.com/plugins/restricted-site-access-wordpress/
  * Description:       <strong>Limit access your site</strong> to visitors who are logged in or accessing the site from a set of specific IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. <strong>Powerful control over redirection</strong>, including <strong>SEO friendly redirect headers</strong>. Great solution for Extranets, publicly hosted Intranets, or parallel development sites.
  * Version:           7.5.0
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP tested-up-to 6.6, the minimum to 6.4, and updates the e2e tests to using 6.4 as the minimum as well.  It also removes the table of contents from the readme now that GitHub auto-generates that.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #316.

### How to test the Change
Use Plugin ZIP action to get version from this PR and run through critical flows, otherwise review results of e2e tests.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.6.
> Changed - Bump WordPress minimum supported version to 6.4.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
