### PR TITLE
Fix missing text domain

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1301,14 +1301,14 @@ class Restricted_Site_Access {
 			}
 			?>
 			<div class="rsa_unrestricted_ip_row">
-				<input type="text" name="rsa_options[allowed][]" class="ip code" placeholder="<?php esc_attr_e( 'IP Address or Range' ); ?>" size="20" />
-				<input type="text" name="rsa_options[comment][]" class="newipcomment" placeholder="<?php esc_attr_e( 'Identify this entry' ); ?>" size="20" />
+				<input type="text" name="rsa_options[allowed][]" class="ip code" placeholder="<?php esc_attr_e( 'IP Address or Range', 'restricted-site-access' ); ?>" size="20" />
+				<input type="text" name="rsa_options[comment][]" class="newipcomment" placeholder="<?php esc_attr_e( 'Identify this entry', 'restricted-site-access' ); ?>" size="20" />
 				<a href="#remove" class="remove_btn"><?php echo esc_html( _x( 'Remove', 'remove IP address action', 'restricted-site-access' ) ); ?></a>
 			</div>
 			</div>
 			<div id="rsa_add_new_ip_fields">
 				<p class="description"><label><?php esc_html_e( 'Enter a single IP address or a range using a subnet prefix', 'restricted-site-access' ); ?></label></p>
-				<input class="button" type="button" id="addip" value="<?php esc_attr_e( 'Add new IP' ); ?>" style="margin-top: 5px;" />
+				<input class="button" type="button" id="addip" value="<?php esc_attr_e( 'Add new IP', 'restricted-site-access' ); ?>" style="margin-top: 5px;" />
 				<?php if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) : ?>
 					<input class="button" type="button" id="rsa_myip" value="<?php esc_attr_e( 'Add My Current IP Address', 'restricted-site-access' ); ?>" style="margin-top: 5px;" data-myip="<?php echo esc_attr( self::get_client_ip_address() ); ?>" /><br />
 				<?php endif; ?>


### PR DESCRIPTION
This would fix #337 

I used Loco Translate to test this on a local website. So, this is before: 

![image](https://github.com/user-attachments/assets/6bdce03d-ed5c-4dd2-b184-4f4d15f45898)

And after I applied this patch, made a new template and translate the new text lines: 

![image](https://github.com/user-attachments/assets/75f42a52-7347-4f0b-9234-46e1b1c18353)
