### PR TITLE
Run the fields population method on init instead of when the class instance is generated

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -112,7 +112,6 @@ class Restricted_Site_Access {
 		if ( null === $instance ) {
 			$instance = new self();
 			self::add_actions();
-			self::populate_fields_array();
 		}
 
 		return $instance;
@@ -135,6 +134,7 @@ class Restricted_Site_Access {
 		add_action( 'parse_request', array( __CLASS__, 'restrict_access' ), 1 );
 		add_action( 'admin_init', array( __CLASS__, 'admin_init' ), 1 );
 		add_action( 'init', array( __CLASS__, 'generate_nonce' ) );
+		add_action( 'init', array( __CLASS__, 'populate_fields' ) );
 		add_action( 'wp_ajax_rsa_ip_check', array( __CLASS__, 'ajax_rsa_ip_check' ) );
 
 		add_action( 'activate_' . self::$basename, array( __CLASS__, 'activation' ), 10, 1 );
@@ -158,6 +158,13 @@ class Restricted_Site_Access {
 	 */
 	public static function generate_nonce() {
 		self::$redirection_nonce = wp_create_nonce( 'redirection_nonce' );
+	}
+
+	/**
+	 * Populates the fields array with the field information.
+	 */
+	public static function populate_fields() {
+		self::populate_fields_array();
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
The problem here is that the plugin was attempting to localize some strings very early, the moment the class instance was generated. Since this was too early, the call of the method was moved to a callback of the `init` action.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #339

### How to test the Change
The notice was thrown on any request, provided that the plugin was active. Browsing the site and not seeing the warning in the logs, while the plugin's setting remain usable, should be the best way to test that the issue is resolved.

### Changelog Entry

> Fixed - PHP Notice that the function "_load_textdomain_just_in_time" was called incorrectly.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
