### PR TITLE
Add "RSA_NETWORK_MODE" constant for Network Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ When the 'Discourage search engines from indexing this site' option is enabled, 
 
 When this option is activated, it serves as a barrier to all visitors except those who are authenticated (logged in) or whose IP addresses are included in the 'Unrestricted IP addresses' setting. This restriction applies universally, even to automated crawlers such as search engines.
 
+### How can I programmatically define default mode for the network?
+
+In your `wp-config.php` file, you can define the following:
+
+```php
+define( 'RSA_NETWORK_MODE', 'enforce' );
+```
+
+There are only two values supported for this constant at the moment: **enforce** or **default**.
+
+If it is set to be non-allowed value, then it will assume as **default**.
+
 ## Support Level
 
 **Stable:** 10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns. We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes. We otherwise intend to keep this tested up to the most recent version of WordPress.

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -313,6 +313,23 @@ class Restricted_Site_Access {
 	}
 
 	/**
+	 * Get the network mode from the RSA_NETWORK_MODE constant.
+	 *
+	 * @return string
+	 */
+	private static function get_config_network_mode() {
+		/**
+		 * Get the network mode from the RSA_NETWORK_MODE constant.
+		 * Only allow 'enforce' or 'default'.
+		 */
+		if ( defined( 'RSA_NETWORK_MODE' ) && in_array( RSA_NETWORK_MODE, array( 'enforce', 'default' ), true ) ) {
+			return RSA_NETWORK_MODE;
+		}
+
+		return '';
+	}
+
+	/**
 	 * Get current plugin network mode
 	 */
 	private static function get_network_mode() {
@@ -320,8 +337,9 @@ class Restricted_Site_Access {
 		 * Get the network mode from the RSA_NETWORK_MODE constant.
 		 * Only allow 'enforce' or 'default'.
 		 */
-		if ( defined( 'RSA_NETWORK_MODE' ) && in_array( RSA_NETWORK_MODE, array( 'enforce', 'default' ), true ) ) {
-			return RSA_NETWORK_MODE;
+		$config_network_mode = self::get_config_network_mode();
+		if ( ! empty( $config_network_mode ) ) {
+			return $config_network_mode;
 		}
 
 		if ( RSA_IS_NETWORK ) {
@@ -754,11 +772,13 @@ class Restricted_Site_Access {
 	 * Show RSA Settings in Network Settings
 	 */
 	public static function show_network_settings() {
-		$mode = self::get_network_mode();
+		$mode                = self::get_network_mode();
+		$config_network_mode = self::get_config_network_mode();
+		$mode_css_class      = empty( $config_network_mode ) ? '' : 'rsa-config-network-mode-enabled';
 		?>
 			<h2><?php esc_html_e( 'Restricted Site Access Settings', 'restricted-site-access' ); ?></h2>
 			<table id="restricted-site-access-mode" class="form-table">
-				<tr>
+				<tr class="<?php echo esc_attr( $mode_css_class ); ?>">
 					<th scope="row"><?php esc_html_e( 'Mode', 'restricted-site-access' ); ?></th>
 					<td>
 						<fieldset>
@@ -768,6 +788,15 @@ class Restricted_Site_Access {
 						</fieldset>
 					</td>
 				</tr>
+				<?php if ( ! empty( $config_network_mode ) ) { ?>
+					<tr class="rsa-network-enforced-warning">
+						<td colspan="2">
+							<div class="notice notice-warning inline">
+								<p><strong><?php echo esc_html__( 'The mode is currently enforced by code configuration.', 'restricted-site-access' ); ?></strong></p>
+							</div>
+						</td>
+					</tr>
+				<?php } ?>
 				<tr class="option-site-visibility">
 					<th scope="row"><?php esc_html_e( 'Site Visibility', 'restricted-site-access' ); ?></th>
 					<?php
@@ -1140,7 +1169,8 @@ class Restricted_Site_Access {
 		);
 		?>
 <style>
-.rsa-enforced .option-site-visibility {
+.rsa-enforced .option-site-visibility,
+.rsa-config-network-mode-enabled {
 	opacity: 0.5;
 	pointer-events: none;
 }

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -316,6 +316,14 @@ class Restricted_Site_Access {
 	 * Get current plugin network mode
 	 */
 	private static function get_network_mode() {
+		/**
+		 * Get the network mode from the RSA_NETWORK_MODE constant.
+		 * Only allow 'enforce' or 'default'.
+		 */
+		if ( defined( 'RSA_NETWORK_MODE' ) && in_array( RSA_NETWORK_MODE, array( 'enforce', 'default' ), true ) ) {
+			return RSA_NETWORK_MODE;
+		}
+
 		if ( RSA_IS_NETWORK ) {
 			return get_site_option( 'rsa_mode', 'default' );
 		}

--- a/tests/php/fixtures/private-access.php
+++ b/tests/php/fixtures/private-access.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Helper trait allowing access to private and protected methods and properties.
+ *
+ * @package PrivateAccess
+ */
+
+use ReflectionClass;
+
+/**
+ * Trait PrivateAccess
+ *
+ * @package Fixtures
+ */
+trait PrivateAccess {
+
+	/**
+	 * Get a private or protected property from an object.
+	 *
+	 * @param object $class_object Object to get property from.
+	 * @param string $property     Property to get.
+	 *
+	 * @return mixed
+	 */
+	public function get_private_property( $class_object, $property ) {
+
+		$reflection = new ReflectionClass( $class_object );
+
+		$property = $reflection->getProperty( $property );
+		$property->setAccessible( true );
+
+		return $property->getValue( $class_object );
+	}
+
+	/**
+	 * Set a private or protected property on an object.
+	 *
+	 * @param object $class_object Object to set property on.
+	 * @param string $property     Property to set.
+	 * @param mixed  $value        Value to set.
+	 *
+	 * @return void
+	 */
+	public function set_private_property( $class_object, $property, $value ) {
+
+		$reflection = new ReflectionClass( $class_object );
+
+		$property = $reflection->getProperty( $property );
+		$property->setAccessible( true );
+		$property->setValue( $class_object, $value );
+	}
+
+	/**
+	 * Call a private or protected method on an object.
+	 *
+	 * @param object $class_object Object to call method on.
+	 * @param string $method       Method to call.
+	 * @param array  $args         Arguments to pass to method.
+	 *
+	 * @return mixed
+	 */
+	public function call_private_method( $class_object, $method, array $args = array() ) {
+
+		$reflection = new ReflectionClass( $class_object );
+
+		$method = $reflection->getMethod( $method );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $class_object, $args );
+	}
+}

--- a/tests/php/multisite/test-restrictions.php
+++ b/tests/php/multisite/test-restrictions.php
@@ -2,6 +2,8 @@
 
 class Restricted_Site_Access_Test_Multisite_Restrictions extends WP_UnitTestCase {
 
+	use PrivateAccess;
+
 	public function test_multisite_restrict_access_not_restricted() {
 
 		$rsa = Restricted_Site_Access::get_instance();
@@ -157,4 +159,29 @@ class Restricted_Site_Access_Test_Multisite_Restrictions extends WP_UnitTestCase
 		$this->assertContains( 'You shall not pass this multisite!', $results['die_message'] );
 	}
 
+	/**
+	 * Test the network mode constant.
+	 */
+	public function test_multisite_network_mode_constant() {
+
+		$rsa = Restricted_Site_Access::get_instance();
+
+		define( 'RSA_NETWORK_MODE', 'enforce' );
+
+		$network_mode = $this->call_private_method(
+			$rsa,
+			'get_network_mode'
+		);
+
+		$this->assertSame( 'enforce', $network_mode );
+
+		define( 'RSA_NETWORK_MODE', 'not-allowed-value' );
+
+		$network_mode = $this->call_private_method(
+			$rsa,
+			'get_network_mode'
+		);
+
+		$this->assertSame( 'default', $network_mode );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Add new `RSA_NETWORK_MODE` constant to define default setting for network mode for multisite.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #317

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Network activate the plugin on multisite
2. Add `define( 'RSA_NETWORK_MODE', 'enforce' );` or `define( 'RSA_NETWORK_MODE', 'default' );` to your site's `wp-config.php` file.
3. It should use that setting across the network.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New `RSA_NETWORK_MODE` constant to define default setting for network mode for multisite

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sanketio 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
