### PR TITLE
Make sure IP addresses can be set properly on the network settings screen

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -1372,7 +1372,6 @@ class Restricted_Site_Access {
 	 * Fieldset for managing allowed IP addresses.
 	 */
 	public static function settings_field_allowed() {
-		$show_partial_cache_explanation = empty( self::get_ips() );
 		?>
 		<div class="hide-if-no-js rsa-ip-addresses-field-wrapper">
 			<div class="rsa-ip-addresses-caching-notice">
@@ -1387,24 +1386,20 @@ class Restricted_Site_Access {
 				<p>
 					<?php esc_html_e( 'RSA attempts to prevent full page caching on sites with an IP address allow list. This is to prevent the page content from being stored at the caching level and displayed to unauthorized visitors.', 'restricted-site-access' ); ?><br />
 					<?php
-					if ( $show_partial_cache_explanation ) {
-						printf(
-							'<a href="#" class="rsa-learn-more-link hide-if-no-js">%s</a>',
-							esc_html__( '[Learn more]', 'restricted-site-access' )
-						);
-					}
+					printf(
+						'<a href="#" class="rsa-learn-more-link hide-if-no-js">%s</a>',
+						esc_html__( '[Learn more]', 'restricted-site-access' )
+					);
 					?>
 				</p>
 
-				<p class="rsa-learn-more-content <?php echo $show_partial_cache_explanation ? 'hide-if-js' : ''; ?>">
+				<p class="rsa-learn-more-content hide-if-js">
 					<?php esc_html_e( 'Page caching plugins often hook into WordPress to quickly serve the last cached output of a page before we can check to see if a visitor’s access should be restricted. Not all page caching plugins behave the same way, but several solutions – including external solutions we might not detect – can ignore the no-caching headers set by WordPress and show cached content to unauthorized users.', 'restricted-site-access' ); ?><br />
 					<?php
-					if ( $show_partial_cache_explanation ) {
-						printf(
-							'<a href="#" class="rsa-learn-more-less-link hide-if-no-js">%s</a>',
-							esc_html__( '[Show less]', 'restricted-site-access' )
-						);
-					}
+					printf(
+						'<a href="#" class="rsa-learn-more-less-link hide-if-no-js">%s</a>',
+						esc_html__( '[Show less]', 'restricted-site-access' )
+					);
 					?>
 				</p>
 			</div>


### PR DESCRIPTION
### Description of the Change

Coming out of some changes we made to show a more thorough message around impacts of caching, ran into an issue where IP addresses weren't saving properly on the network settings screen.

Looking into it, the issue was a call to the `get_ips` method, as this will always pull settings from the site level, not network level.

Now we could update that method to work properly in both situations but in looking at how we were using this method, it seems we use the output of this to decide if we show a more robust caching message, i.e. if someone has IP addresses they've unrestricted, we then show a more robust message.

Unless I'm missing something here, seems fine to show that message to all users, whether they have IP addresses allowed or not. That fixes the problem here and I don't think there's any downside to showing that extra messaging, though I'm open to feedback here.

### How to test the Change

1. Network activate RSA
2. Go to the network settings screen and ensure you can add IP addresses, save those and have those persist after a refresh
3. Activate RSA only on the site-level
4. Test the same but at the site-level instead of network level, ensuring things save properly

### Changelog Entry

> Fixed - Ensure IP addresses can be saved properly at the network level

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
