### PR TITLE
Ensure fields are set before we use them

### DIFF
--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -841,6 +841,11 @@ class Restricted_Site_Access {
 			( RSA_IS_NETWORK && 'enforce' !== self::get_network_mode() ) || // Show on single (network) site when not enforced at the network level.
 			! RSA_IS_NETWORK // Show on single non-network sites.
 		) {
+			// Populate fields if they are not set.
+			if ( is_null( self::$fields ) ) {
+				self::populate_fields_array();
+			}
+
 			foreach ( self::$fields as $field_name => $field_data ) {
 				add_settings_field(
 					$field_name,
@@ -861,6 +866,12 @@ class Restricted_Site_Access {
 
 		// Add settings fields that should always be visible.
 		add_settings_section( 'restricted-site-access-always-visible', '', '__return_empty_string', self::$settings_page );
+
+		// Populate fields if they are not set.
+		if ( is_null( self::$always_visible_fields ) ) {
+			self::populate_fields_array();
+		}
+
 		foreach ( self::$always_visible_fields as $field_name => $field_data ) {
 
 			// Add field to the section, along with the default classes.

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -423,6 +423,11 @@ class Restricted_Site_Access {
 			$options = get_option( 'rsa_options', array() );
 		}
 
+		// Populate fields if they are not set.
+		if ( is_null( self::$fields ) || is_null( self::$always_visible_fields ) ) {
+			self::populate_fields_array();
+		}
+
 		// Merge fields that should always be visible with the rest of the fields.
 		$all_fields = array_merge( self::$fields, self::$always_visible_fields );
 


### PR DESCRIPTION
### Description of the Change

As reported in #370, there's a situation that can arise where the fields data we want to use isn't set properly and so when we try and use it, this causes errors.

Note I wasn't able to reproduce this myself and in looking at the code, it seems this data should always be set before we try using it (it gets set on the `init` hook). But there's obviously some situations that lead to this not being the case. So this PR adds in a call to `populate_fields_array` if that data isn't set to ensure it gets set before we use it. This same approach is used in multiple places across the plugin so seems like an issue we've run into before.

Edit: was able to reproduce using Elementor so seems a conflict with them (and potentially other plugins). Did verify that the fix here solves things though.

Closes #370 

### How to test the Change

1. Install Elementor
2. Edit a post using Elementor
3. Notice that on `develop`, a fatal error will occur
4. Notice on this PR, the error won't happen
 
### Changelog Entry

> Fixed - Ensure the field data is set properly before we use it. Resolves a fatal error with Elementor.

### Credits

Props @ktorktor, @dkotter, @peterwilsoncc 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
