### PR TITLE
Update .gitattributes to modify export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,4 @@
 /package.json export-ignore
 /phpunit.xml export-ignore
 /README.md export-ignore
-/run-wpacceptance.sh export-ignore
-/wpacceptance.json export-ignore
 /webpack.config.js export-ignore


### PR DESCRIPTION
### Description of the Change

This pull request makes a minor update to the `.gitattributes` file, removing two entries from the export-ignore list as the files are no longer part of the repo / we're not using WP Acceptance.


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
