### PR TITLE
Bump tested up to header to indicate WordPress 6.9 support.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, jakemgold, rcbth, thinkoomph, tlovett1, jeffpaul, nomnom99
 Donate link:       https://10up.com/plugins/restricted-site-access-wordpress/
 Tags:              privacy, restrict, limited, permissions, security
-Tested up to:      6.8
+Tested up to:      6.9
 Stable tag:        7.6.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

Bump tested up to header to indicate WordPress 6.9 support.

Closes #374 

### How to test the Change

N/A: See testing notes on the related issue.

### Changelog Entry
> Changed - Bump tested up to header to indicate WordPress 6.9 support.

### Credits
Props @peterwilsoncc 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
