### PR TITLE
WordPress 7.1 Compatibility Updates

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -53,7 +53,7 @@ jobs:
         core:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.9'}
 
     steps:
     - name: Checkout

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, jakemgold, rcbth, thinkoomph, tlovett1, jeffpaul, nomnom99
 Donate link:       https://10up.com/plugins/restricted-site-access-wordpress/
 Tags:              privacy, restrict, limited, permissions, security
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        7.6.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -150,7 +150,7 @@ class Restricted_Site_Access {
 
 		add_action( 'activate_' . self::$basename, array( __CLASS__, 'activation' ), 10, 1 );
 		add_action( 'deactivate_' . self::$basename, array( __CLASS__, 'deactivation' ), 10, 1 );
-		add_action( 'wpmu_new_blog', array( __CLASS__, 'set_defaults' ) );
+		add_action( 'wp_initialize_site', array( __CLASS__, 'set_defaults' ), 10, 1 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_script' ) );
 		add_action( 'wp_ajax_rsa_notice_dismiss', array( __CLASS__, 'ajax_notice_dismiss' ) );
 
@@ -302,11 +302,11 @@ class Restricted_Site_Access {
 	}
 
 	/**
-	 * Set RSA defaults for new site.
+	 * Set RSA defaults for a new site.
 	 *
-	 * @param int    $blog_id New site/blog ID.
+	 * @param WP_Site $new_site New site object.
 	 */
-	public static function set_defaults( $blog_id ) {
+	public static function set_defaults( $new_site ) {
 		if ( 'enforce' === self::get_network_mode() ) {
 			return;
 		}
@@ -315,7 +315,7 @@ class Restricted_Site_Access {
 		$blog_public     = get_site_option( 'blog_public', 2 );
 
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog -- Only used to set options/change DB prefix.
-		switch_to_blog( $blog_id );
+		switch_to_blog( $new_site->id );
 		update_option( 'rsa_options', self::sanitize_options( $network_options ) );
 		update_option( 'blog_public', (int) $blog_public );
 		restore_current_blog();

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -304,9 +304,15 @@ class Restricted_Site_Access {
 	/**
 	 * Set RSA defaults for a new site.
 	 *
-	 * @param WP_Site $new_site New site object.
+	 * @param WP_Site $new_site New site object ID.
 	 */
 	public static function set_defaults( $new_site ) {
+		$new_site = get_site( $new_site );
+
+		if ( ! $new_site ) {
+			return;
+		}
+
 		if ( 'enforce' === self::get_network_mode() ) {
 			return;
 		}

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://10up.com/plugins/restricted-site-access-wordpress/
  * Description:       <strong>Limit access your site</strong> to visitors who are logged in or accessing the site from a set of specific IP addresses. Send restricted visitors to the log in page, redirect them, or display a message or page. <strong>Powerful control over redirection</strong>, including <strong>SEO friendly redirect headers</strong>. Great solution for Extranets, publicly hosted Intranets, or parallel development sites.
  * Version:           7.6.1
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/restricted_site_access.php
+++ b/restricted_site_access.php
@@ -304,7 +304,7 @@ class Restricted_Site_Access {
 	/**
 	 * Set RSA defaults for a new site.
 	 *
-	 * @param WP_Site $new_site New site object ID.
+	 * @param WP_Site|int $new_site New site object or ID.
 	 */
 	public static function set_defaults( $new_site ) {
 		$new_site = get_site( $new_site );

--- a/tests/php/multisite/test-settings.php
+++ b/tests/php/multisite/test-settings.php
@@ -141,7 +141,7 @@ class Restricted_Site_Access_Test_Multisite_Settings extends WP_UnitTestCase {
 
 			restore_current_blog();
 
-			$rsa::set_defaults( $site->blog_id, null, null, null, null, null );
+			$rsa::set_defaults( $site );
 
 			switch_to_blog( $site->blog_id );
 
@@ -173,7 +173,7 @@ class Restricted_Site_Access_Test_Multisite_Settings extends WP_UnitTestCase {
 
 			restore_current_blog();
 
-			$rsa::set_defaults( $site->blog_id, null, null, null, null, null );
+			$rsa::set_defaults( $site );
 
 			switch_to_blog( $site->blog_id );
 

--- a/tests/php/test-actions.php
+++ b/tests/php/test-actions.php
@@ -12,7 +12,7 @@ class Restricted_Site_Access_Test_Actions extends WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'wp_ajax_rsa_ip_check', array( 'Restricted_Site_Access', 'ajax_rsa_ip_check' ) ) );
 		$this->assertSame( 10, has_action( 'activate_' . RSA_TEST_PLUGIN_BASENAME, array( 'Restricted_Site_Access', 'activation' ) ) );
 		$this->assertSame( 10, has_action( 'deactivate_' . RSA_TEST_PLUGIN_BASENAME, array( 'Restricted_Site_Access', 'deactivation' ) ) );
-		$this->assertSame( 10, has_action( 'wpmu_new_blog', array( 'Restricted_Site_Access', 'set_defaults' ) ) );
+		$this->assertSame( 10, has_action( 'wp_initialize_site', array( 'Restricted_Site_Access', 'set_defaults' ) ) );
 		$this->assertSame( 10, has_action( 'admin_enqueue_scripts', array( 'Restricted_Site_Access', 'enqueue_admin_script' ) ) );
 		$this->assertSame( 10, has_action( 'wp_ajax_rsa_notice_dismiss', array( 'Restricted_Site_Access', 'ajax_notice_dismiss' ) ) );
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Replace the deprecated `wpmu_new_blog` action with `wp_initialize_site` when copying Restricted Site Access network defaults onto a newly created site.

`wpmu_new_blog` has been deprecated since WordPress 5.1 and now only fires through `do_action_deprecated()`. This plugin requires WordPress 6.6, so a version fallback is not needed. Core still initializes the site at priority 10 on `wp_initialize_site` first; RSA then copies network `rsa_options` and `blog_public` onto the new site, same as before.

`Restricted_Site_Access::set_defaults()` now receives a WP_Site object and uses `$new_site->id` instead of a numeric blog ID. Direct callers that still pass an integer (or the old six-argument `wpmu_new_blog` signature) will need to pass a `WP_Site` instance.

Unit tests were updated to assert the new hook and to pass `WP_Site` objects from `get_sites()`.

**Benefits**: Removes `WP_DEBUG` deprecation notices on new site creation and uses the current Multisite site-initialization API.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #427

### How to test the Change

1. On a multisite install with Restricted Site Access network-activated, set network RSA settings (including `blog_public` / restrict access) and leave network mode not on `enforce`.
2. Create a new site (Network Admin → Sites → Add New).
3. Switch to that site and confirm `rsa_options` and `blog_public` match the network defaults.
4. Set network mode to enforce, create another new site, and confirm site-level RSA options are not written (enforced network settings still apply).
5. With `WP_DEBUG` and `WP_DEBUG_LOG` enabled, create a site and confirm this plugin does not log a `wpmu_new_blog` deprecation notice.
6. Run the PHPUnit suite, including the multisite tests (test-actions.php and tests/php/multisite/test-settings.php).

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Deprecated - Soon-to-be removed feature

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @phpbits 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
