### PR TITLE
E2E Tests: Plugin title row now uses a th.

### DIFF
--- a/tests/cypress/e2e/activation-deactivation.test.js
+++ b/tests/cypress/e2e/activation-deactivation.test.js
@@ -11,17 +11,17 @@ describe( 'Activation/Deactivation', () => {
 
 	it( 'Plugin activation', () => {
 		cy.visitAdminPage( 'network/plugins.php' );
-		cy.contains( 'strong', 'Restricted Site Access' ).closest( 'td' ).find( '.activate > a' ).click();
+		cy.contains( 'strong', 'Restricted Site Access' ).closest( 'td,th' ).find( '.activate > a' ).click();
 	} );
 
 	it( 'Plugin deactivation', () => {
 		cy.visitAdminPage( 'network/plugins.php' );
-		cy.contains( 'strong', 'Restricted Site Access' ).closest( 'td' ).find( '.deactivate > a' ).click();
+		cy.contains( 'strong', 'Restricted Site Access' ).closest( 'td,th' ).find( '.deactivate > a' ).click();
 		cy.get( '#rsa-user-message' ).type( 'I understand' );
 		cy.get( 'button' ).contains( 'Network Disable Plugin' ).click();
 	} );
 
 	after( () => {
-		cy.contains( 'strong', 'Restricted Site Access' ).closest( 'td' ).find( '.activate > a' ).click();
+		cy.contains( 'strong', 'Restricted Site Access' ).closest( 'td,th' ).find( '.activate > a' ).click();
 	} );
 } );


### PR DESCRIPTION
### Description of the Change
Updates the selector used for plugin activation/deactivation to account for a change in WordPress 7.0 to use a `th` element for the plugin name cell in the plugin list table.

Closes #434 

### How to test the Change

1. Observe passing tests: https://github.com/10up/restricted-site-access/actions/runs/32930602978

### Changelog Entry
> Developer - E2E Tests: update selector used for plugin activation/deactivation tests.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
